### PR TITLE
Use setter/getter for player-networks

### DIFF
--- a/add_target.lua
+++ b/add_target.lua
@@ -50,50 +50,51 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
    end
 
    -- first one by this player?
-   if( not( travelnet.targets[ owner_name ] )) then
-      travelnet.targets[       owner_name ] = {};
+   if not travelnet.get_networks(owner_name) then
+      travelnet.set_networks(owner_name, {})
    end
 
+   local networks = travelnet.get_networks(owner_name)
+
    -- first station on this network?
-   if( not( travelnet.targets[ owner_name ][ network_name ] )) then
-      travelnet.targets[       owner_name ][ network_name ] = {};
+   if not networks[network_name] then
+      networks[network_name] = {}
    end
 
    -- lua doesn't allow efficient counting here
    local anz = 0;
-   for k in pairs( travelnet.targets[ owner_name ][ network_name ] ) do
-
-      if( k == station_name ) then
+   for k in pairs(networks[network_name]) do
+      if  k == station_name then
          travelnet.show_message( pos, player_name, S("Error"),
-	    S("A station named '@1' already exists on this network. Please choose a different name!", station_name));
+	    S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
          return;
       end
 
-      anz = anz + 1;
+      anz = anz + 1
    end
 
    -- we don't want too many stations in the same network because that would get confusing when displaying the targets
    if( anz+1 > travelnet.MAX_STATIONS_PER_NETWORK ) then
       travelnet.show_message( pos, player_name, S("Error"),
 	S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
-	"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK));
+	"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
       return;
    end
 
    -- add this station
-   travelnet.targets[ owner_name ][ network_name ][ station_name ] = {pos=pos, timestamp=os.time() };
+   local timestamp = os.time()
+   networks[network_name][station_name] = {pos=pos, timestamp=timestamp }
 
    -- do we have a new node to set up? (and are not just reading from a safefile?)
-   if( meta ) then
-
+   if meta then
       minetest.chat_send_player(player_name, S("Station '@1'" .." "..
 		"has been added to the network '@2'" ..
-		", which now consists of @3 station(s).", station_name, network_name, anz+1));
+		", which now consists of @3 station(s).", station_name, network_name, anz+1))
 
-      meta:set_string( "station_name",    station_name );
-      meta:set_string( "station_network", network_name );
-      meta:set_string( "owner",           owner_name );
-      meta:set_int( "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp);
+      meta:set_string( "station_name", station_name)
+      meta:set_string( "station_network", network_name)
+      meta:set_string( "owner", owner_name)
+      meta:set_int("timestamp", timestamp);
 
       meta:set_string("formspec",
                      "size[12,10]"..
@@ -105,7 +106,7 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
       -- display a list of all stations that can be reached from here
       travelnet.update_formspec( pos, player_name, nil );
 
-      -- save the updated network data in a savefile over server restart
-      travelnet.save_data();
+      -- save networks
+      travelnet.set_networks(owner_name, networks)
    end
 end

--- a/elevator.lua
+++ b/elevator.lua
@@ -4,34 +4,35 @@
 local S = minetest.get_translator("travelnet")
 
 travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
-	if( not( pos ) or not(pos.x) or not(pos.z) or not( owner_name )) then
-		return;
+	if not pos or not pos.x or not pos.z or not owner_name then
+		return
 	end
 
-	if( not( travelnet.targets[ owner_name ] )) then
+	if travelnet.get_networks(owner_name) then
 		minetest.chat_send_player( owner_name, S("Congratulations! This is your first elevator. "..
 			"You can build an elevator network by placing further elevators somewhere above "..
-			"or below this one. Just make sure that the x and z coordinate are the same."));
+			"or below this one. Just make sure that the x and z coordinate are the same."))
 		return;
 	end
 
-	local network_name = tostring( pos.x )..','..tostring( pos.z );
+	local network_name = tostring( pos.x )..','..tostring( pos.z )
+	local networks = travelnet.get_networks(owner_name)
 	-- will this be an elevator that will be added to an existing network?
-	if( travelnet.targets[ owner_name ][ network_name ]
+	if( networks[network_name]
 	  -- does the network have any members at all?
-	  and next( travelnet.targets[ owner_name ][ network_name ], nil )) then
+	  and next( networks[network_name], nil )) then
 		minetest.chat_send_player( owner_name, S("This elevator will automaticly connect to the "..
 			"other elevators you have placed at different heights. Just enter a station name "..
 			"and click on \"store\" to set it up. Or just punch it to set the height as station "..
-			"name."));
-		return;
+			"name."))
+		return
 	end
 
 	local nearest_name = "";
 	local nearest_dist = 100000000;
 	local nearest_dist_x = 0;
 	local nearest_dist_z = 0;
-	for target_network_name, data in pairs( travelnet.targets[ owner_name ] ) do
+	for target_network_name, data in pairs(networks) do
 		local station_name = next( data, nil );
 		if( station_name and data[ station_name ][ "nr" ] and data[ station_name ].pos) then
 			local station_pos = data[ station_name ].pos;

--- a/functions.lua
+++ b/functions.lua
@@ -127,23 +127,27 @@ travelnet.remove_box = function(_, _, oldmetadata, digger )
 		return;
 	end
 
-	local owner_name      = oldmetadata.fields[ "owner" ];
-	local station_name    = oldmetadata.fields[ "station_name" ];
-	local station_network = oldmetadata.fields[ "station_network" ];
+	local owner_name = oldmetadata.fields["owner" ]
+	local station_name = oldmetadata.fields["station_name"]
+	local station_network = oldmetadata.fields["station_network"]
+	local networks = travelnet.get_networks(owner_name)
 
 	-- station is not known? then just remove it
-	if(  not( owner_name )
-		or not( station_name )
-		or not( station_network )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
+	if  not owner_name
+		or not station_name
+		or not station_network
+		or not networks
+		or not networks[station_network] then
 
 		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
-		S("Could not find the station that is to be removed."));
+		S("Could not find the station that is to be removed."))
 		return;
 	end
 
-	travelnet.targets[ owner_name ][ station_network ][ station_name ] = nil;
+	networks[station_network][station_name] = nil
+
+	-- save changed data
+	travelnet.set_networks(owner_name, networks)
 
 	-- inform the owner
 	minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
@@ -154,7 +158,7 @@ travelnet.remove_box = function(_, _, oldmetadata, digger )
 	end
 
 	-- save the updated network data in a savefile over server restart
-	travelnet.save_data();
+	travelnet.set_networks(owner_name, networks)
 end
 
 

--- a/init.lua
+++ b/init.lua
@@ -31,7 +31,6 @@ end
 
 travelnet = {};
 
-travelnet.targets = {};
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
 -- privs

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -77,8 +77,8 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 
 
 	-- if the box has not been configured yet
-	if( meta:get_string("station_network")=="" ) then
-		travelnet.add_target( fields.station_name, fields.station_network, pos, name, meta, fields.owner );
+	if meta:get_string("station_network") == "" then
+		travelnet.add_target(fields.station_name, fields.station_network, pos, name, meta, fields.owner)
 		return;
 	end
 
@@ -100,78 +100,75 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 
 
 	-- if there is something wrong with the data
-	local owner_name      = meta:get_string( "owner" );
-	local station_name    = meta:get_string( "station_name" );
-	local station_network = meta:get_string( "station_network" );
+	local owner_name = meta:get_string("owner")
+	local station_name = meta:get_string("station_name")
+	local station_network = meta:get_string("station_network")
+	local networks = travelnet.get_networks(owner_name)
 
-	if(  not( owner_name  )
-		or not( station_name )
-		or not( station_network )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
+	if not owner_name
+		or not station_name
+		or not station_network
+		or not networks
+		or not networks[station_network] then
 
-			if owner_name
-				and station_name
-				and station_network then
-					travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name );
+			if owner_name and station_name and station_network then
+					travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
 				else
 					minetest.chat_send_player(name, S("Error")..": "..
 						S("There is something wrong with the configuration of this station.")..
 						" DEBUG DATA: owner: "..(  owner_name or "?")..
 						" station_name: "..(station_name or "?")..
 						" station_network: "..(station_network or "?").."."
-					);
+					)
 				return
 			end
 	end
 
-	if(  not( owner_name )
-		or not( station_network )
-		or not( travelnet.targets )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
+	if not owner_name
+		or not station_network
+		or not networks
+		or not networks[station_network] then
 			minetest.chat_send_player(name, S("Error")..": "..
 				S("This travelnet is lacking data and/or improperly configured."));
 				print( "ERROR: The travelnet at "..minetest.pos_to_string( pos ).." has a problem: "..
 				" DATA: owner: "..(  owner_name or "?")..
 				" station_name: "..(station_name or "?")..
 				" station_network: "..(station_network or "?").."."
-			);
-		return;
+			)
+		return
 	end
 
-	local this_node = minetest.get_node( pos );
+	local this_node = minetest.get_node(pos)
 	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
-		for k,_ in pairs( travelnet.targets[ owner_name ][ station_network ] ) do
-			if( travelnet.targets[ owner_name ][ station_network ][ k ].nr
-			== fields.target) then
-				fields.target = k;
+		for k,_ in pairs(networks[station_network]) do
+			if networks[station_network][k].nr == fields.target then
+				fields.target = k
 			end
 		end
 	end
 
 	-- if the target station is gone
-	if not travelnet.targets[ owner_name ][ station_network ][ fields.target ] then
+	if not networks[station_network][fields.target] then
 		minetest.chat_send_player(name, S("Station '@1' does not exist (anymore?)" ..
 			" " .. "on this network.", fields.target or "?")
-		);
-		travelnet.update_formspec( pos, name, nil );
-		return;
+		)
+		travelnet.update_formspec( pos, name, nil )
+		return
 	end
 
 
-	if( not( travelnet.allow_travel( name, owner_name, station_network, station_name, fields.target ))) then
-		return;
+	if not travelnet.allow_travel(name, owner_name, station_network, station_name, fields.target) then
+		return
 	end
-	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"));
+	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"))
 
 
 
 	if travelnet.travelnet_sound_enabled then
 		if this_node.name == 'travelnet:elevator' then
-			minetest.sound_play("travelnet_bell", {pos = pos, gain = 0.75, max_hear_distance = 10,});
+			minetest.sound_play("travelnet_bell", {pos = pos, gain = 0.75, max_hear_distance = 10,})
 		else
-			minetest.sound_play("travelnet_travel", {pos = pos, gain = 0.75, max_hear_distance = 10,});
+			minetest.sound_play("travelnet_travel", {pos = pos, gain = 0.75, max_hear_distance = 10,})
 		end
 	end
 
@@ -187,7 +184,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	-- may be 0.0 for some versions of MT 5 player model
 	local player_model_bottom = tonumber(minetest.settings:get("player_model_bottom")) or -.5;
 	local player_model_vec = vector.new(0, player_model_bottom, 0);
-	local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos;
+	local target_pos = networks[station_network][fields.target].pos
 
 	local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
 	local top_node = minetest.get_node(top_pos)

--- a/persistence.lua
+++ b/persistence.lua
@@ -1,37 +1,51 @@
 local S = minetest.get_translator("travelnet")
 
 local mod_data_path = minetest.get_worldpath().."/mod_travelnet.data"
+local travelnet_data = {}
 
--- called whenever a station is added or removed
-travelnet.save_data = function()
+-- TODO: deprecate (use get/set_networks below)
+-- TODO: check if "travelnet.save_data" is used in other mods (jumpdrive?)
+local function save_data()
+   local data = minetest.serialize(travelnet_data)
 
-   local data = minetest.serialize( travelnet.targets );
-
-   local success = minetest.safe_file_write( mod_data_path, data );
-   if( not success ) then
-      print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path));
+   local success = minetest.safe_file_write(mod_data_path, data)
+   if not success then
+      print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path))
    end
 end
 
-
-travelnet.restore_data = function()
-
-   local file = io.open( mod_data_path, "r" );
-   if( not file ) then
-      print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path));
-      return;
+-- loads all the travelnets
+-- TODO: deprecate (use get/set_networks below)
+function travelnet.restore_data()
+   local file = io.open(mod_data_path, "r")
+   if not file then
+      print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path))
+      return
    end
 
-   local data = file:read("*all");
-   travelnet.targets = minetest.deserialize( data );
+   local data = file:read("*all")
+   travelnet_data = minetest.deserialize(data)
 
-   if( not travelnet.targets ) then
+   if not travelnet_data then
        local backup_file = mod_data_path..".bak"
        print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-       "Saved the backup as '@2'.", mod_data_path, backup_file));
+         "Saved the backup as '@2'.", mod_data_path, backup_file))
 
-       minetest.safe_file_write( backup_file, data );
-       travelnet.targets = {};
+       minetest.safe_file_write( backup_file, data )
+       travelnet_data = {}
    end
-   file:close();
+   file:close()
+end
+
+-- accessor function for player travelnet-data
+-- TODO: load data on-demand
+function travelnet.get_networks(owner_name)
+   return travelnet_data[owner_name]
+end
+
+-- setter function for player travelnets
+-- TODO: save on demand
+function travelnet.set_networks(owner_name, networks)
+   travelnet_data[owner_name] = networks
+   save_data() --TODO: remove afterwards
 end

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -4,16 +4,17 @@ minetest.register_abm({
 	interval = 20,
 	chance = 1,
 	action = function(pos)
-		local meta = minetest.get_meta( pos );
-		local owner_name      = meta:get_string( "owner" );
-		local station_name    = meta:get_string( "station_name" );
-		local station_network = meta:get_string( "station_network" );
+		local meta = minetest.get_meta(pos)
+		local owner_name = meta:get_string("owner")
+		local station_name = meta:get_string("station_name")
+		local station_network = meta:get_string("station_network")
+		local networks = travelnet.get_networks(owner_name)
 
 		if( owner_name and station_name and station_network
-			and ( not( travelnet.targets )
-			or not( travelnet.targets[ owner_name ] )
-			or not( travelnet.targets[ owner_name ][ station_network ] )
-			or not( travelnet.targets[ owner_name ][ station_network ][ station_name ] ))) then
+			and (
+			not networks
+			or not networks[station_network]
+			or not networks[station_network][station_name] )) then
 
 				travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name );
 				print( 'TRAVELNET: re-adding '..tostring( station_name )..' to '..


### PR DESCRIPTION
First stage for a per-player storage backend

Adds:
* `travelnet.get_networks(owner)` to load data
* `travelnet.set_networks(owner, networks)` to save data

currently both functions just call the legacy stuff afterwards

## TODO

* [ ] compat for the `metatool`
* [ ] proper api docs

## Dependent PR's

* https://github.com/pandorabox-io/pandorabox_custom/pull/43
* https://github.com/mt-mods/jumpdrive/pull/96

## Next steps

* Add migration path for per-player save-files (`world/travelnet/<playername>.json`)