### PR TITLE
Linting and code formatting

### DIFF
--- a/add_target.lua
+++ b/add_target.lua
@@ -83,7 +83,8 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 	-- do we have a new node to set up? (and are not just reading from a safefile?)
 	if meta then
 		minetest.chat_send_player(player_name,
-				S("Station '@1' has been added to the network '@2'" ..
+				S("Station '@1'" .. " " ..
+					"has been added to the network '@2'" ..
 					", which now consists of @3 station(s).", station_name, network_name, anz+1))
 
 		meta:set_string("station_name",    station_name)

--- a/add_target.lua
+++ b/add_target.lua
@@ -18,13 +18,13 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 	end
 
 	if station_name == "" or not station_name then
-		travelnet.show_message( pos, player_name, S("Error"), S("Please provide a name for this station." ))
+		travelnet.show_message( pos, player_name, S("Error"), S("Please provide a name for this station.") )
 		return
 	end
 
 	if network_name == "" or not network_name then
 		travelnet.show_message( pos, player_name, S("Error"),
-			S("Please provide the name of the network this station ought to be connected to."))
+			S("Please provide the name of the network this station ought to be connected to.") )
 		return
 	end
 
@@ -34,18 +34,18 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 	elseif is_elevator then -- elevator networks
 		owner_name = player_name
 
-	elseif not minetest.check_player_privs(player_name, {interact=true}) then
+	elseif not minetest.check_player_privs( player_name, { interact = true } ) then
 
 		travelnet.show_message( pos, player_name, S("Error"),
-			S("There is no player with interact privilege named '@1'. Aborting.", tostring( player_name)))
+			S("There is no player with interact privilege named '@1'. Aborting.", tostring( player_name )))
 		return
 
-	elseif not minetest.check_player_privs(player_name, {travelnet_attach=true})
+	elseif not minetest.check_player_privs( player_name, { travelnet_attach = true } )
 		and not travelnet.allow_attach( player_name, owner_name, network_name ) then
 
 		travelnet.show_message( pos, player_name, S("Error"),
 			S("You do not have the travelnet_attach priv which is required to attach your box to "..
-			"the network of someone else. Aborting."))
+			"the network of someone else. Aborting.") )
 		return
 	end
 
@@ -64,7 +64,7 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 	for k in pairs( travelnet.targets[ owner_name ][ network_name ] ) do
 		if k == station_name then
 			travelnet.show_message( pos, player_name, S("Error"),
-				S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
+				S("A station named '@1' already exists on this network. Please choose a different name!", station_name) )
 			return
 		end
 		anz = anz + 1
@@ -74,30 +74,30 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 	if anz+1 > travelnet.MAX_STATIONS_PER_NETWORK then
 		travelnet.show_message( pos, player_name, S("Error"),
 			S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
-			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
+			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK) )
 		return
 	end
 
 	-- add this station
-	travelnet.targets[ owner_name ][ network_name ][ station_name ] = {pos=pos, timestamp=os.time() }
+	travelnet.targets[ owner_name ][ network_name ][ station_name ] = { pos = pos, timestamp = os.time() }
 
 	-- do we have a new node to set up? (and are not just reading from a safefile?)
 	if meta then
-		minetest.chat_send_player(player_name, S("Station '@1'" .." "..
+		minetest.chat_send_player( player_name, S("Station '@1'" .." "..
 			"has been added to the network '@2'" ..
-			", which now consists of @3 station(s).", station_name, network_name, anz+1))
+			", which now consists of @3 station(s).", station_name, network_name, anz+1) )
 
 		meta:set_string( "station_name",    station_name )
 		meta:set_string( "station_network", network_name )
 		meta:set_string( "owner",           owner_name )
-		meta:set_int(    "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp)
+		meta:set_int(    "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp )
 
-		meta:set_string("formspec",
+		meta:set_string( "formspec",
 			"size[12,10]"..
 			"field[0.3,0.6;6,0.7;station_name;"..S("Station:")..";"..
-			minetest.formspec_escape(meta:get_string("station_name")).."]"..
+			minetest.formspec_escape( meta:get_string("station_name") ).."]"..
 			"field[0.3,3.6;6,0.7;station_network;"..S("Network:")..";"..
-			minetest.formspec_escape(meta:get_string("station_network")).."]" )
+			minetest.formspec_escape( meta:get_string("station_network") ).."]" )
 
 		-- display a list of all stations that can be reached from here
 		travelnet.update_formspec( pos, player_name, nil )

--- a/add_target.lua
+++ b/add_target.lua
@@ -11,7 +11,7 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 	if this_node.name == 'travelnet:elevator' then
 		--      owner_name   = '*'; -- the owner name is not relevant here
 		is_elevator  = true
-		network_name = tostring(pos.x)..','..tostring(pos.z)
+		network_name = tostring(pos.x) .. ',' .. tostring(pos.z)
 		if not station_name or station_name == '' then
 			station_name = S("at @1 m", tostring(pos.y))
 		end
@@ -24,28 +24,24 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 
 	if network_name == "" or not network_name then
 		travelnet.show_message(pos, player_name, S("Error"),
-			S("Please provide the name of the network this station ought to be connected to."))
+				S("Please provide the name of the network this station ought to be connected to."))
 		return
 	end
 
 	if owner_name == nil or owner_name == '' or owner_name == player_name then
 		owner_name = player_name
-
 	elseif is_elevator then -- elevator networks
 		owner_name = player_name
-
 	elseif not minetest.check_player_privs(player_name, { interact=true }) then
-
 		travelnet.show_message(pos, player_name, S("Error"),
-			S("There is no player with interact privilege named '@1'. Aborting.", tostring(player_name)))
+				S("There is no player with interact privilege named '@1'. Aborting.", tostring(player_name)))
 		return
-
-	elseif not minetest.check_player_privs(player_name, { travelnet_attach=true })
-		and not travelnet.allow_attach(player_name, owner_name, network_name) then
-
+	elseif  not minetest.check_player_privs(player_name, { travelnet_attach=true })
+		and not travelnet.allow_attach(player_name, owner_name, network_name)
+	then
 		travelnet.show_message(pos, player_name, S("Error"),
-			S("You do not have the travelnet_attach priv which is required to attach your box to "..
-			"the network of someone else. Aborting."))
+				S("You do not have the travelnet_attach priv which is required to attach your box to " ..
+					"the network of someone else. Aborting."))
 		return
 	end
 
@@ -64,17 +60,17 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 	for k in pairs(travelnet.targets[owner_name][network_name]) do
 		if k == station_name then
 			travelnet.show_message(pos, player_name, S("Error"),
-				S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
+					S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
 			return
 		end
-		anz = anz + 1
+		anz = anz+1
 	end
 
 	-- we don't want too many stations in the same network because that would get confusing when displaying the targets
 	if anz+1 > travelnet.MAX_STATIONS_PER_NETWORK then
 		travelnet.show_message(pos, player_name, S("Error"),
-			S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
-			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
+				S("Network '@1', already contains the maximum number (@2) of allowed stations per network. " ..
+					"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
 		return
 	end
 
@@ -86,9 +82,9 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 
 	-- do we have a new node to set up? (and are not just reading from a safefile?)
 	if meta then
-		minetest.chat_send_player(player_name, S("Station '@1'" .." "..
-			"has been added to the network '@2'" ..
-			", which now consists of @3 station(s).", station_name, network_name, anz+1))
+		minetest.chat_send_player(player_name,
+				S("Station '@1' has been added to the network '@2'" ..
+					", which now consists of @3 station(s).", station_name, network_name, anz+1))
 
 		meta:set_string("station_name",    station_name)
 		meta:set_string("station_network", network_name)
@@ -96,11 +92,11 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 		meta:set_int   ("timestamp",       travelnet.targets[owner_name][network_name][station_name].timestamp)
 
 		meta:set_string("formspec",
-			"size[12,10]"..
-			"field[0.3,0.6;6,0.7;station_name;"..S("Station:")..";"..
-			minetest.formspec_escape(meta:get_string("station_name")).."]"..
-			"field[0.3,3.6;6,0.7;station_network;"..S("Network:")..";"..
-			minetest.formspec_escape(meta:get_string("station_network")).."]")
+			"size[12,10]" ..
+			"field[0.3,0.6;6,0.7;station_name;" .. S("Station:") .. ";" ..
+			minetest.formspec_escape(meta:get_string("station_name")) .. "]" ..
+			"field[0.3,3.6;6,0.7;station_network;" .. S("Network:") .. ";" ..
+			minetest.formspec_escape(meta:get_string("station_network")) .. "]")
 
 		-- display a list of all stations that can be reached from here
 		travelnet.update_formspec(pos, player_name, nil)

--- a/add_target.lua
+++ b/add_target.lua
@@ -2,29 +2,29 @@ local S = minetest.get_translator("travelnet")
 
 
 -- add a new target; meta is optional
-travelnet.add_target = function( station_name, network_name, pos, player_name, meta, owner_name )
+travelnet.add_target = function(station_name, network_name, pos, player_name, meta, owner_name)
 
 	-- if it is an elevator, determine the network name through x and z coordinates
-	local this_node   = minetest.get_node( pos )
+	local this_node   = minetest.get_node(pos)
 	local is_elevator = false
 
 	if this_node.name == 'travelnet:elevator' then
 		--      owner_name   = '*'; -- the owner name is not relevant here
 		is_elevator  = true
-		network_name = tostring( pos.x )..','..tostring( pos.z )
+		network_name = tostring(pos.x)..','..tostring(pos.z)
 		if not station_name or station_name == '' then
-			station_name = S("at @1 m", tostring( pos.y ))
+			station_name = S("at @1 m", tostring(pos.y))
 		end
 	end
 
 	if station_name == "" or not station_name then
-		travelnet.show_message( pos, player_name, S("Error"), S("Please provide a name for this station.") )
+		travelnet.show_message(pos, player_name, S("Error"), S("Please provide a name for this station."))
 		return
 	end
 
 	if network_name == "" or not network_name then
-		travelnet.show_message( pos, player_name, S("Error"),
-			S("Please provide the name of the network this station ought to be connected to.") )
+		travelnet.show_message(pos, player_name, S("Error"),
+			S("Please provide the name of the network this station ought to be connected to."))
 		return
 	end
 
@@ -34,37 +34,37 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 	elseif is_elevator then -- elevator networks
 		owner_name = player_name
 
-	elseif not minetest.check_player_privs( player_name, { interact = true } ) then
+	elseif not minetest.check_player_privs(player_name, { interact=true }) then
 
-		travelnet.show_message( pos, player_name, S("Error"),
-			S("There is no player with interact privilege named '@1'. Aborting.", tostring( player_name )))
+		travelnet.show_message(pos, player_name, S("Error"),
+			S("There is no player with interact privilege named '@1'. Aborting.", tostring(player_name)))
 		return
 
-	elseif not minetest.check_player_privs( player_name, { travelnet_attach = true } )
-		and not travelnet.allow_attach( player_name, owner_name, network_name ) then
+	elseif not minetest.check_player_privs(player_name, { travelnet_attach=true })
+		and not travelnet.allow_attach(player_name, owner_name, network_name) then
 
-		travelnet.show_message( pos, player_name, S("Error"),
+		travelnet.show_message(pos, player_name, S("Error"),
 			S("You do not have the travelnet_attach priv which is required to attach your box to "..
-			"the network of someone else. Aborting.") )
+			"the network of someone else. Aborting."))
 		return
 	end
 
 	-- first one by this player?
-	if not travelnet.targets[ owner_name ] then
-		travelnet.targets[ owner_name ] = {}
+	if not travelnet.targets[owner_name] then
+		travelnet.targets[owner_name] = {}
 	end
 
 	-- first station on this network?
-	if not travelnet.targets[ owner_name ][ network_name ] then
-		travelnet.targets[ owner_name ][ network_name ] = {}
+	if not travelnet.targets[owner_name][network_name] then
+		travelnet.targets[owner_name][network_name] = {}
 	end
 
 	-- lua doesn't allow efficient counting here
 	local anz = 0
-	for k in pairs( travelnet.targets[ owner_name ][ network_name ] ) do
+	for k in pairs(travelnet.targets[owner_name][network_name]) do
 		if k == station_name then
-			travelnet.show_message( pos, player_name, S("Error"),
-				S("A station named '@1' already exists on this network. Please choose a different name!", station_name) )
+			travelnet.show_message(pos, player_name, S("Error"),
+				S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
 			return
 		end
 		anz = anz + 1
@@ -72,35 +72,38 @@ travelnet.add_target = function( station_name, network_name, pos, player_name, m
 
 	-- we don't want too many stations in the same network because that would get confusing when displaying the targets
 	if anz+1 > travelnet.MAX_STATIONS_PER_NETWORK then
-		travelnet.show_message( pos, player_name, S("Error"),
+		travelnet.show_message(pos, player_name, S("Error"),
 			S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
-			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK) )
+			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
 		return
 	end
 
 	-- add this station
-	travelnet.targets[ owner_name ][ network_name ][ station_name ] = { pos = pos, timestamp = os.time() }
+	travelnet.targets[owner_name][network_name][station_name] = {
+		pos = pos,
+		timestamp = os.time()
+	}
 
 	-- do we have a new node to set up? (and are not just reading from a safefile?)
 	if meta then
-		minetest.chat_send_player( player_name, S("Station '@1'" .." "..
+		minetest.chat_send_player(player_name, S("Station '@1'" .." "..
 			"has been added to the network '@2'" ..
-			", which now consists of @3 station(s).", station_name, network_name, anz+1) )
+			", which now consists of @3 station(s).", station_name, network_name, anz+1))
 
-		meta:set_string( "station_name",    station_name )
-		meta:set_string( "station_network", network_name )
-		meta:set_string( "owner",           owner_name )
-		meta:set_int(    "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp )
+		meta:set_string("station_name",    station_name)
+		meta:set_string("station_network", network_name)
+		meta:set_string("owner",           owner_name)
+		meta:set_int   ("timestamp",       travelnet.targets[owner_name][network_name][station_name].timestamp)
 
-		meta:set_string( "formspec",
+		meta:set_string("formspec",
 			"size[12,10]"..
 			"field[0.3,0.6;6,0.7;station_name;"..S("Station:")..";"..
-			minetest.formspec_escape( meta:get_string("station_name") ).."]"..
+			minetest.formspec_escape(meta:get_string("station_name")).."]"..
 			"field[0.3,3.6;6,0.7;station_network;"..S("Network:")..";"..
-			minetest.formspec_escape( meta:get_string("station_network") ).."]" )
+			minetest.formspec_escape(meta:get_string("station_network")).."]")
 
 		-- display a list of all stations that can be reached from here
-		travelnet.update_formspec( pos, player_name, nil )
+		travelnet.update_formspec(pos, player_name, nil)
 
 		-- save the updated network data in a savefile over server restart
 		travelnet.save_data()

--- a/add_target.lua
+++ b/add_target.lua
@@ -4,108 +4,105 @@ local S = minetest.get_translator("travelnet")
 -- add a new target; meta is optional
 travelnet.add_target = function( station_name, network_name, pos, player_name, meta, owner_name )
 
-   -- if it is an elevator, determine the network name through x and z coordinates
-   local this_node   = minetest.get_node( pos );
-   local is_elevator = false;
+	-- if it is an elevator, determine the network name through x and z coordinates
+	local this_node   = minetest.get_node( pos )
+	local is_elevator = false
 
-   if( this_node.name == 'travelnet:elevator' ) then
---      owner_name   = '*'; -- the owner name is not relevant here
-      is_elevator  = true;
-      network_name = tostring( pos.x )..','..tostring( pos.z );
-      if( not( station_name ) or station_name == '' ) then
-         station_name = S("at @1 m", tostring( pos.y ));
-      end
-   end
+	if this_node.name == 'travelnet:elevator' then
+		--      owner_name   = '*'; -- the owner name is not relevant here
+		is_elevator  = true
+		network_name = tostring( pos.x )..','..tostring( pos.z )
+		if not station_name or station_name == '' then
+			station_name = S("at @1 m", tostring( pos.y ))
+		end
+	end
 
-   if( station_name == "" or not(station_name )) then
-      travelnet.show_message( pos, player_name, S("Error"), S("Please provide a name for this station." ));
-      return;
-   end
+	if station_name == "" or not station_name then
+		travelnet.show_message( pos, player_name, S("Error"), S("Please provide a name for this station." ))
+		return
+	end
 
-   if( network_name == "" or not( network_name )) then
-      travelnet.show_message( pos, player_name, S("Error"),
-	S("Please provide the name of the network this station ought to be connected to."));
-      return;
-   end
+	if network_name == "" or not network_name then
+		travelnet.show_message( pos, player_name, S("Error"),
+			S("Please provide the name of the network this station ought to be connected to."))
+		return
+	end
 
-   if(     owner_name == nil or owner_name == '' or owner_name == player_name) then
-      owner_name = player_name;
+	if owner_name == nil or owner_name == '' or owner_name == player_name then
+		owner_name = player_name
 
-   elseif( is_elevator ) then -- elevator networks
-      owner_name = player_name;
+	elseif is_elevator then -- elevator networks
+		owner_name = player_name
 
-   elseif( not( minetest.check_player_privs(player_name, {interact=true}))) then
+	elseif not minetest.check_player_privs(player_name, {interact=true}) then
 
-      travelnet.show_message( pos, player_name, S("Error"),
-	S("There is no player with interact privilege named '@1'. Aborting.", tostring( player_name)));
-      return;
+		travelnet.show_message( pos, player_name, S("Error"),
+			S("There is no player with interact privilege named '@1'. Aborting.", tostring( player_name)))
+		return
 
-   elseif( not( minetest.check_player_privs(player_name, {travelnet_attach=true}))
-       and not( travelnet.allow_attach( player_name, owner_name, network_name ))) then
+	elseif not minetest.check_player_privs(player_name, {travelnet_attach=true})
+		and not travelnet.allow_attach( player_name, owner_name, network_name ) then
 
-      travelnet.show_message( pos, player_name, S("Error"),
-	S("You do not have the travelnet_attach priv which is required to attach your box to "..
-	"the network of someone else. Aborting."));
-      return;
-   end
+		travelnet.show_message( pos, player_name, S("Error"),
+			S("You do not have the travelnet_attach priv which is required to attach your box to "..
+			"the network of someone else. Aborting."))
+		return
+	end
 
-   -- first one by this player?
-   if( not( travelnet.targets[ owner_name ] )) then
-      travelnet.targets[       owner_name ] = {};
-   end
+	-- first one by this player?
+	if not travelnet.targets[ owner_name ] then
+		travelnet.targets[ owner_name ] = {}
+	end
 
-   -- first station on this network?
-   if( not( travelnet.targets[ owner_name ][ network_name ] )) then
-      travelnet.targets[       owner_name ][ network_name ] = {};
-   end
+	-- first station on this network?
+	if not travelnet.targets[ owner_name ][ network_name ] then
+		travelnet.targets[ owner_name ][ network_name ] = {}
+	end
 
-   -- lua doesn't allow efficient counting here
-   local anz = 0;
-   for k in pairs( travelnet.targets[ owner_name ][ network_name ] ) do
+	-- lua doesn't allow efficient counting here
+	local anz = 0
+	for k in pairs( travelnet.targets[ owner_name ][ network_name ] ) do
+		if k == station_name then
+			travelnet.show_message( pos, player_name, S("Error"),
+				S("A station named '@1' already exists on this network. Please choose a different name!", station_name))
+			return
+		end
+		anz = anz + 1
+	end
 
-      if( k == station_name ) then
-         travelnet.show_message( pos, player_name, S("Error"),
-	    S("A station named '@1' already exists on this network. Please choose a different name!", station_name));
-         return;
-      end
+	-- we don't want too many stations in the same network because that would get confusing when displaying the targets
+	if anz+1 > travelnet.MAX_STATIONS_PER_NETWORK then
+		travelnet.show_message( pos, player_name, S("Error"),
+			S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
+			"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
+		return
+	end
 
-      anz = anz + 1;
-   end
+	-- add this station
+	travelnet.targets[ owner_name ][ network_name ][ station_name ] = {pos=pos, timestamp=os.time() }
 
-   -- we don't want too many stations in the same network because that would get confusing when displaying the targets
-   if( anz+1 > travelnet.MAX_STATIONS_PER_NETWORK ) then
-      travelnet.show_message( pos, player_name, S("Error"),
-	S("Network '@1', already contains the maximum number (@2) of allowed stations per network. "..
-	"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK));
-      return;
-   end
+	-- do we have a new node to set up? (and are not just reading from a safefile?)
+	if meta then
+		minetest.chat_send_player(player_name, S("Station '@1'" .." "..
+			"has been added to the network '@2'" ..
+			", which now consists of @3 station(s).", station_name, network_name, anz+1))
 
-   -- add this station
-   travelnet.targets[ owner_name ][ network_name ][ station_name ] = {pos=pos, timestamp=os.time() };
+		meta:set_string( "station_name",    station_name )
+		meta:set_string( "station_network", network_name )
+		meta:set_string( "owner",           owner_name )
+		meta:set_int(    "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp)
 
-   -- do we have a new node to set up? (and are not just reading from a safefile?)
-   if( meta ) then
+		meta:set_string("formspec",
+			"size[12,10]"..
+			"field[0.3,0.6;6,0.7;station_name;"..S("Station:")..";"..
+			minetest.formspec_escape(meta:get_string("station_name")).."]"..
+			"field[0.3,3.6;6,0.7;station_network;"..S("Network:")..";"..
+			minetest.formspec_escape(meta:get_string("station_network")).."]" )
 
-      minetest.chat_send_player(player_name, S("Station '@1'" .." "..
-		"has been added to the network '@2'" ..
-		", which now consists of @3 station(s).", station_name, network_name, anz+1));
+		-- display a list of all stations that can be reached from here
+		travelnet.update_formspec( pos, player_name, nil )
 
-      meta:set_string( "station_name",    station_name );
-      meta:set_string( "station_network", network_name );
-      meta:set_string( "owner",           owner_name );
-      meta:set_int( "timestamp",       travelnet.targets[ owner_name ][ network_name ][ station_name ].timestamp);
-
-      meta:set_string("formspec",
-                     "size[12,10]"..
-                     "field[0.3,0.6;6,0.7;station_name;"..S("Station:")..";"..
-										 minetest.formspec_escape(meta:get_string("station_name")).."]"..
-                     "field[0.3,3.6;6,0.7;station_network;"..S("Network:")..";"..
-										 minetest.formspec_escape(meta:get_string("station_network")).."]" );
-
-      -- display a list of all stations that can be reached from here
-      travelnet.update_formspec( pos, player_name, nil );
-
-      -- save the updated network data in a savefile over server restart
-      travelnet.save_data();
-   end
+		-- save the updated network data in a savefile over server restart
+		travelnet.save_data()
+	end
 end

--- a/add_target.lua
+++ b/add_target.lua
@@ -9,7 +9,7 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 	local is_elevator = false
 
 	if this_node.name == "travelnet:elevator" then
-		--      owner_name   = "*"; -- the owner name is not relevant here
+		--      owner_name   = "*"  -- the owner name is not relevant here
 		is_elevator  = true
 		network_name = tostring(pos.x) .. "," .. tostring(pos.z)
 		if not station_name or station_name == "" then
@@ -92,11 +92,11 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 		meta:set_int   ("timestamp",       travelnet.targets[owner_name][network_name][station_name].timestamp)
 
 		meta:set_string("formspec",
-			"size[12,10]" ..
-			"field[0.3,0.6;6,0.7;station_name;" .. S("Station:") .. ";" ..
-			minetest.formspec_escape(meta:get_string("station_name")) .. "]" ..
-			"field[0.3,3.6;6,0.7;station_network;" .. S("Network:") .. ";" ..
-			minetest.formspec_escape(meta:get_string("station_network")) .. "]")
+				"size[12,10]" ..
+				"field[0.3,0.6;6,0.7;station_name;" .. S("Station:") .. ";" ..
+				minetest.formspec_escape(meta:get_string("station_name")) .. "]" ..
+				"field[0.3,3.6;6,0.7;station_network;" .. S("Network:") .. ";" ..
+				minetest.formspec_escape(meta:get_string("station_network")) .. "]")
 
 		-- display a list of all stations that can be reached from here
 		travelnet.update_formspec(pos, player_name, nil)

--- a/add_target.lua
+++ b/add_target.lua
@@ -8,11 +8,11 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 	local this_node   = minetest.get_node(pos)
 	local is_elevator = false
 
-	if this_node.name == 'travelnet:elevator' then
-		--      owner_name   = '*'; -- the owner name is not relevant here
+	if this_node.name == "travelnet:elevator" then
+		--      owner_name   = "*"; -- the owner name is not relevant here
 		is_elevator  = true
-		network_name = tostring(pos.x) .. ',' .. tostring(pos.z)
-		if not station_name or station_name == '' then
+		network_name = tostring(pos.x) .. "," .. tostring(pos.z)
+		if not station_name or station_name == "" then
 			station_name = S("at @1 m", tostring(pos.y))
 		end
 	end
@@ -28,7 +28,7 @@ travelnet.add_target = function(station_name, network_name, pos, player_name, me
 		return
 	end
 
-	if owner_name == nil or owner_name == '' or owner_name == player_name then
+	if owner_name == nil or owner_name == "" or owner_name == player_name then
 		owner_name = player_name
 	elseif is_elevator then -- elevator networks
 		owner_name = player_name

--- a/config.lua
+++ b/config.lua
@@ -1,60 +1,60 @@
 
-travelnet.MAX_STATIONS_PER_NETWORK = 24;
+travelnet.MAX_STATIONS_PER_NETWORK = 24
 
 -- set this to true if you want a simulated beam effect
-travelnet.travelnet_effect_enabled = false;
+travelnet.travelnet_effect_enabled = false
 -- set this to true if you want a sound to be played when the travelnet is used
-travelnet.travelnet_sound_enabled  = false;
+travelnet.travelnet_sound_enabled  = false
 
 -- if you set this to false, travelnets cannot be created
 -- (this may be useful if you want nothing but the elevators on your server)
-travelnet.travelnet_enabled        = true;
+travelnet.travelnet_enabled        = true
 -- if you set travelnet.elevator_enabled to false, you will not be able to
 -- craft, place or use elevators
-travelnet.elevator_enabled         = true;
+travelnet.elevator_enabled         = true
 -- if you set this to false, doors will be disabled
-travelnet.doors_enabled            = true;
+travelnet.doors_enabled            = true
 
 -- starts an abm which re-adds travelnet stations to networks in case the savefile got lost
-travelnet.abm_enabled              = false;
+travelnet.abm_enabled              = false
 
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
-                {"default:glass", "default:steel_ingot", "default:glass", },
-                {"default:glass", "default:mese",        "default:glass", },
-                {"default:glass", "default:steel_ingot", "default:glass", }
+	{"default:glass", "default:steel_ingot", "default:glass", },
+	{"default:glass", "default:mese",        "default:glass", },
+	{"default:glass", "default:steel_ingot", "default:glass", }
 }
 travelnet.elevator_recipe = {
-	        {"default:steel_ingot", "default:glass", "default:steel_ingot", },
-		{"default:steel_ingot", "",              "default:steel_ingot", },
-		{"default:steel_ingot", "default:glass", "default:steel_ingot", }
+	{"default:steel_ingot", "default:glass", "default:steel_ingot", },
+	{"default:steel_ingot", "",              "default:steel_ingot", },
+	{"default:steel_ingot", "default:glass", "default:steel_ingot", }
 }
 travelnet.tiles_elevator = {
-		"travelnet_elevator_front.png",
-		"travelnet_elevator_inside_controls.png",
-		"travelnet_elevator_sides_outside.png",
-		"travelnet_elevator_inside_ceiling.png",
-		"travelnet_elevator_inside_floor.png",
-		"default_steel_block.png"
-		}
+	"travelnet_elevator_front.png",
+	"travelnet_elevator_inside_controls.png",
+	"travelnet_elevator_sides_outside.png",
+	"travelnet_elevator_inside_ceiling.png",
+	"travelnet_elevator_inside_floor.png",
+	"default_steel_block.png"
+}
 travelnet.elevator_inventory_image  = "travelnet_elevator_inv.png"
 
-if( minetest.registered_nodes["mcl_core:wood"]) then
+if minetest.registered_nodes["mcl_core:wood"] then
 	travelnet.travelnet_recipe = {
-                {"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
+		{"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
 		{"mesecons_torch:mesecon_torch_on", "mcl_chests:chest", "mesecons_torch:mesecon_torch_on"},
 		{"mesecons_torch:mesecon_torch_on", "mcl_chests:chest", "mesecons_torch:mesecon_torch_on"},
---		  {"core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", },
---                {"mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass", },
---                {"mcl_core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", }
+		-- {"core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", },
+		-- {"mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass", },
+		-- {"mcl_core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", }
 	}
 	travelnet.elevator_recipe = {
-                {"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
+		{"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
 		{"mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on"},
 		{"mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on"},
---	        {"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", },
---		{"mcl_core:iron_ingot", "",               "mcl_core:iron_ingot", },
---		{"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", }
+		-- {"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", },
+		-- {"mcl_core:iron_ingot", "",               "mcl_core:iron_ingot", },
+		-- {"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", }
 	}
 	travelnet.tiles_elevator = {
 		"mcl_core_planks_big_oak.png^[transformR90", -- front
@@ -63,7 +63,7 @@ if( minetest.registered_nodes["mcl_core:wood"]) then
 		"mcl_core_planks_big_oak.png^[transformR90", -- inside ceiling
 		"mcl_core_planks_big_oak.png^[transformR90", -- inside floor
 		"mcl_core_planks_big_oak.png^[transformR90", -- top
-		}
+	}
 	travelnet.elevator_inventory_image  = nil
 end
 
@@ -76,7 +76,7 @@ end
 -- can still add stations to that network
 -- params: player_name, owner_name, network_name
 travelnet.allow_attach = function()
-	return false;
+	return false
 end
 
 
@@ -85,7 +85,7 @@ end
 -- has the travelnet_remove priv
 -- params: player_name, owner_name, network_name, pos
 travelnet.allow_dig = function()
-   return false;
+	return false
 end
 
 
@@ -97,7 +97,7 @@ end
 -- usage of stations to players in the same fraction on PvP servers
 -- params: player_name, owner_name, network_name, station_name_start, station_name_target
 travelnet.allow_travel = function()
-   return true;
+	return true
 end
 
 travelnet.travelnet_sound_enabled = true

--- a/config.lua
+++ b/config.lua
@@ -20,14 +20,14 @@ travelnet.abm_enabled              = false
 
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
-	{"default:glass", "default:steel_ingot", "default:glass" },
-	{"default:glass", "default:mese",        "default:glass" },
-	{"default:glass", "default:steel_ingot", "default:glass" }
+	{ "default:glass", "default:steel_ingot", "default:glass" },
+	{ "default:glass", "default:mese",        "default:glass" },
+	{ "default:glass", "default:steel_ingot", "default:glass" }
 }
 travelnet.elevator_recipe = {
-	{"default:steel_ingot", "default:glass", "default:steel_ingot" },
-	{"default:steel_ingot", "",              "default:steel_ingot" },
-	{"default:steel_ingot", "default:glass", "default:steel_ingot" }
+	{ "default:steel_ingot", "default:glass", "default:steel_ingot" },
+	{ "default:steel_ingot", "",              "default:steel_ingot" },
+	{ "default:steel_ingot", "default:glass", "default:steel_ingot" }
 }
 travelnet.tiles_elevator = {
 	"travelnet_elevator_front.png",

--- a/config.lua
+++ b/config.lua
@@ -39,7 +39,7 @@ travelnet.tiles_elevator = {
 }
 travelnet.elevator_inventory_image  = "travelnet_elevator_inv.png"
 
-if minetest.registered_nodes[ "mcl_core:wood" ] then
+if minetest.registered_nodes["mcl_core:wood"] then
 	travelnet.travelnet_recipe = {
 		{ "mcl_stairs:slab_wood",            "mcl_stairs:slab_wood", "mcl_stairs:slab_wood" },
 		{ "mesecons_torch:mesecon_torch_on", "mcl_chests:chest",     "mesecons_torch:mesecon_torch_on" },
@@ -64,7 +64,7 @@ if minetest.registered_nodes[ "mcl_core:wood" ] then
 		"mcl_core_planks_big_oak.png^[transformR90", -- inside floor
 		"mcl_core_planks_big_oak.png^[transformR90", -- top
 	}
-	travelnet.elevator_inventory_image  = nil
+	travelnet.elevator_inventory_image = nil
 end
 
 -- if this function returns true, the player with the name player_name is

--- a/config.lua
+++ b/config.lua
@@ -20,14 +20,14 @@ travelnet.abm_enabled              = false
 
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
-	{"default:glass", "default:steel_ingot", "default:glass", },
-	{"default:glass", "default:mese",        "default:glass", },
-	{"default:glass", "default:steel_ingot", "default:glass", }
+	{"default:glass", "default:steel_ingot", "default:glass" },
+	{"default:glass", "default:mese",        "default:glass" },
+	{"default:glass", "default:steel_ingot", "default:glass" }
 }
 travelnet.elevator_recipe = {
-	{"default:steel_ingot", "default:glass", "default:steel_ingot", },
-	{"default:steel_ingot", "",              "default:steel_ingot", },
-	{"default:steel_ingot", "default:glass", "default:steel_ingot", }
+	{"default:steel_ingot", "default:glass", "default:steel_ingot" },
+	{"default:steel_ingot", "",              "default:steel_ingot" },
+	{"default:steel_ingot", "default:glass", "default:steel_ingot" }
 }
 travelnet.tiles_elevator = {
 	"travelnet_elevator_front.png",
@@ -39,22 +39,22 @@ travelnet.tiles_elevator = {
 }
 travelnet.elevator_inventory_image  = "travelnet_elevator_inv.png"
 
-if minetest.registered_nodes["mcl_core:wood"] then
+if minetest.registered_nodes[ "mcl_core:wood" ] then
 	travelnet.travelnet_recipe = {
-		{"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
-		{"mesecons_torch:mesecon_torch_on", "mcl_chests:chest", "mesecons_torch:mesecon_torch_on"},
-		{"mesecons_torch:mesecon_torch_on", "mcl_chests:chest", "mesecons_torch:mesecon_torch_on"},
-		-- {"core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", },
-		-- {"mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass", },
-		-- {"mcl_core:glass", "mcl_core:iron_ingot",           "mcl_core:glass", }
+		{ "mcl_stairs:slab_wood",            "mcl_stairs:slab_wood", "mcl_stairs:slab_wood" },
+		{ "mesecons_torch:mesecon_torch_on", "mcl_chests:chest",     "mesecons_torch:mesecon_torch_on" },
+		{ "mesecons_torch:mesecon_torch_on", "mcl_chests:chest",     "mesecons_torch:mesecon_torch_on" },
+		-- { "core:glass",     "mcl_core:iron_ingot",          "mcl_core:glass" },
+		-- { "mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass" },
+		-- { "mcl_core:glass", "mcl_core:iron_ingot",          "mcl_core:glass" }
 	}
 	travelnet.elevator_recipe = {
-		{"mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood",},
-		{"mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on"},
-		{"mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on"},
-		-- {"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", },
-		-- {"mcl_core:iron_ingot", "",               "mcl_core:iron_ingot", },
-		-- {"mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot", }
+		{ "mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood" },
+		{ "mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on" },
+		{ "mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on" },
+		-- { "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" },
+		-- { "mcl_core:iron_ingot", "",               "mcl_core:iron_ingot" },
+		-- { "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" }
 	}
 	travelnet.tiles_elevator = {
 		"mcl_core_planks_big_oak.png^[transformR90", -- front

--- a/doors.lua
+++ b/doors.lua
@@ -41,7 +41,7 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 	minetest.register_node(node_base_name.."_closed", {
 		description = S("elevator door (closed)"),
 		drawtype = "nodebox",
-                -- top, bottom, side1, side2, inner, outer
+		-- top, bottom, side1, side2, inner, outer
 		tiles = def_tiles,
 		use_texture_alpha = "clip",
 		paramtype = "light",
@@ -70,34 +70,36 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 	minetest.register_craft({
 		output = node_base_name.."_closed",
 		recipe = {
-			{material, '', material },
-			{material, '', material },
-			{material, '', material }
+			{ material, '', material },
+			{ material, '', material },
+			{ material, '', material }
 		}
 	})
 
 
 	-- Make doors reacts to mesecons
 	if minetest.get_modpath("mesecons") then
-		local mesecons = {effector = {
-			action_on = function(pos, node)
-			minetest.add_node(pos, {name = node_base_name.."_open", param2 = node.param2})
-		end,
-		action_off = function(pos, node)
-			minetest.add_node(pos, {name = node_base_name.."_closed", param2 = node.param2})
-		end,
-		rules = mesecon.rules.pplate
-	}}
+		local mesecons = {
+			effector = {
+				action_on = function(pos, node)
+					minetest.add_node(pos, {name = node_base_name.."_open", param2 = node.param2})
+				end,
+				action_off = function(pos, node)
+					minetest.add_node(pos, {name = node_base_name.."_closed", param2 = node.param2})
+				end,
+				rules = mesecon.rules.pplate
+			}
+		}
 
-	minetest.override_item( node_base_name.."_closed", { mesecons = mesecons })
-	minetest.override_item( node_base_name.."_open", { mesecons = mesecons })
-   end
+		minetest.override_item( node_base_name.."_closed", { mesecons = mesecons })
+		minetest.override_item( node_base_name.."_open", { mesecons = mesecons })
+	end
 end
 
 -- actually register the doors
 -- (but only if the materials for them exist)
-if(minetest.get_modpath("default")) then
-	travelnet.register_door( "travelnet:elevator_door_steel", {"default_stone.png"}, "default:steel_ingot");
-	travelnet.register_door( "travelnet:elevator_door_glass", {"travelnet_elevator_door_glass.png"}, "default:glass");
-	travelnet.register_door( "travelnet:elevator_door_tin", {"default_clay.png"}, "default:tin_ingot");
+if minetest.get_modpath("default") then
+	travelnet.register_door( "travelnet:elevator_door_steel", {"default_stone.png"}, "default:steel_ingot")
+	travelnet.register_door( "travelnet:elevator_door_glass", {"travelnet_elevator_door_glass.png"}, "default:glass")
+	travelnet.register_door( "travelnet:elevator_door_tin", {"default_clay.png"}, "default:tin_ingot")
 end

--- a/doors.lua
+++ b/doors.lua
@@ -16,29 +16,29 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 		paramtype2 = "facedir",
 		is_ground_content = true,
 		-- only the closed variant is in creative inventory
-		groups = {snappy=2,choppy=2,oddly_breakable_by_hand=2,not_in_creative_inventory=1},
+		groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2, not_in_creative_inventory = 1 },
 		-- larger than one node but slightly smaller than a half node so
 		-- that wallmounted torches pose no problem
 		node_box = {
 			type = "fixed",
 			fixed = {
-				{-0.90, -0.5,  0.4, -0.49, 1.5,  0.5},
-				{ 0.49, -0.5,  0.4,  0.9, 1.5,  0.5},
+				{ -0.90, -0.5, 0.4, -0.49, 1.5, 0.5 },
+				{  0.49, -0.5, 0.4,   0.9, 1.5, 0.5 },
 			},
 		},
 		selection_box = {
 			type = "fixed",
 			fixed = {
-				{-0.9, -0.5,  0.4,  0.9, 1.5,  0.5},
+				{ -0.9, -0.5, 0.4, 0.9, 1.5, 0.5 },
 			},
 		},
 		drop = node_base_name.."_closed",
-		on_rightclick = function(pos, node)
-			minetest.add_node(pos, {name = node_base_name.."_closed", param2 = node.param2})
+		on_rightclick = function( pos, node )
+			minetest.add_node( pos, { name = node_base_name.."_closed", param2 = node.param2 } )
 		end,
 	})
 
-	minetest.register_node(node_base_name.."_closed", {
+	minetest.register_node( node_base_name.."_closed", {
 		description = S("elevator door (closed)"),
 		drawtype = "nodebox",
 		-- top, bottom, side1, side2, inner, outer
@@ -47,59 +47,59 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = true,
-		groups = {snappy=2,choppy=2,oddly_breakable_by_hand=2},
+		groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2 },
 		node_box = {
 			type = "fixed",
 			fixed = {
-				{-0.5,  -0.5,  0.4, -0.01, 1.5,  0.5},
-				{ 0.01, -0.5,  0.4,  0.5,  1.5,  0.5},
+				{ -0.5, -0.5, 0.4, -0.01, 1.5, 0.5 },
+				{ 0.01, -0.5, 0.4,   0.5, 1.5, 0.5 },
 			},
 		},
 		selection_box = {
 			type = "fixed",
 			fixed = {
-				{-0.5, -0.5,  0.4,  0.5, 1.5,  0.5},
+				{ -0.5, -0.5, 0.4, 0.5, 1.5, 0.5 },
 			},
 		},
-		on_rightclick = function(pos, node)
-			minetest.add_node(pos, {name = node_base_name.."_open", param2 = node.param2})
+		on_rightclick = function( pos, node )
+			minetest.add_node( pos, { name = node_base_name.."_open", param2 = node.param2 } )
 		end,
 	})
 
 	-- add a craft receipe for the door
-	minetest.register_craft({
+	minetest.register_craft( {
 		output = node_base_name.."_closed",
 		recipe = {
 			{ material, '', material },
 			{ material, '', material },
 			{ material, '', material }
 		}
-	})
+	} )
 
 
 	-- Make doors reacts to mesecons
 	if minetest.get_modpath("mesecons") then
 		local mesecons = {
 			effector = {
-				action_on = function(pos, node)
-					minetest.add_node(pos, {name = node_base_name.."_open", param2 = node.param2})
+				action_on = function( pos, node )
+					minetest.add_node( pos, { name = node_base_name.."_open",   param2 = node.param2 } )
 				end,
-				action_off = function(pos, node)
-					minetest.add_node(pos, {name = node_base_name.."_closed", param2 = node.param2})
+				action_off = function( pos, node )
+					minetest.add_node( pos, { name = node_base_name.."_closed", param2 = node.param2 } )
 				end,
 				rules = mesecon.rules.pplate
 			}
 		}
 
-		minetest.override_item( node_base_name.."_closed", { mesecons = mesecons })
-		minetest.override_item( node_base_name.."_open", { mesecons = mesecons })
+		minetest.override_item( node_base_name.."_closed", { mesecons = mesecons } )
+		minetest.override_item( node_base_name.."_open",   { mesecons = mesecons } )
 	end
 end
 
 -- actually register the doors
 -- (but only if the materials for them exist)
-if minetest.get_modpath("default") then
-	travelnet.register_door( "travelnet:elevator_door_steel", {"default_stone.png"}, "default:steel_ingot")
-	travelnet.register_door( "travelnet:elevator_door_glass", {"travelnet_elevator_door_glass.png"}, "default:glass")
-	travelnet.register_door( "travelnet:elevator_door_tin", {"default_clay.png"}, "default:tin_ingot")
+if minetest.get_modpath( "default" ) then
+	travelnet.register_door( "travelnet:elevator_door_steel", { "default_stone.png" },                 "default:steel_ingot" )
+	travelnet.register_door( "travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass" )
+	travelnet.register_door( "travelnet:elevator_door_tin",   { "default_clay.png" },                  "default:tin_ingot" )
 end

--- a/doors.lua
+++ b/doors.lua
@@ -120,7 +120,7 @@ end
 -- actually register the doors
 -- (but only if the materials for them exist)
 if minetest.get_modpath("default") then
-	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },                 "default:steel_ingot")
+	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },           "default:steel_ingot")
 	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass")
-	travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },                  "default:tin_ingot")
+	travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },              "default:tin_ingot")
 end

--- a/doors.lua
+++ b/doors.lua
@@ -85,9 +85,9 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 	minetest.register_craft({
 		output = node_base_name .. "_closed",
 		recipe = {
-			{ material, '', material },
-			{ material, '', material },
-			{ material, '', material }
+			{ material, "", material },
+			{ material, "", material },
+			{ material, "", material }
 		}
 	})
 

--- a/doors.lua
+++ b/doors.lua
@@ -4,9 +4,9 @@
 -- Autor: Sokomine
 local S = minetest.get_translator("travelnet")
 
-travelnet.register_door = function( node_base_name, def_tiles, material )
+travelnet.register_door = function(node_base_name, def_tiles, material)
 
-	minetest.register_node( node_base_name.."_open", {
+	minetest.register_node(node_base_name.."_open", {
 		description = S("elevator door (open)"),
 		drawtype = "nodebox",
 		-- top, bottom, side1, side2, inner, outer
@@ -16,7 +16,12 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 		paramtype2 = "facedir",
 		is_ground_content = true,
 		-- only the closed variant is in creative inventory
-		groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2, not_in_creative_inventory = 1 },
+		groups = {
+			snappy = 2,
+			choppy = 2,
+			oddly_breakable_by_hand = 2,
+			not_in_creative_inventory = 1
+		},
 		-- larger than one node but slightly smaller than a half node so
 		-- that wallmounted torches pose no problem
 		node_box = {
@@ -33,12 +38,15 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 			},
 		},
 		drop = node_base_name.."_closed",
-		on_rightclick = function( pos, node )
-			minetest.add_node( pos, { name = node_base_name.."_closed", param2 = node.param2 } )
+		on_rightclick = function(pos, node)
+			minetest.add_node(pos, {
+				name = node_base_name.."_closed",
+				param2 = node.param2
+			})
 		end,
 	})
 
-	minetest.register_node( node_base_name.."_closed", {
+	minetest.register_node(node_base_name.."_closed", {
 		description = S("elevator door (closed)"),
 		drawtype = "nodebox",
 		-- top, bottom, side1, side2, inner, outer
@@ -47,7 +55,11 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = true,
-		groups = { snappy = 2, choppy = 2, oddly_breakable_by_hand = 2 },
+		groups = {
+			snappy = 2,
+			choppy = 2,
+			oddly_breakable_by_hand = 2
+		},
 		node_box = {
 			type = "fixed",
 			fixed = {
@@ -61,45 +73,54 @@ travelnet.register_door = function( node_base_name, def_tiles, material )
 				{ -0.5, -0.5, 0.4, 0.5, 1.5, 0.5 },
 			},
 		},
-		on_rightclick = function( pos, node )
-			minetest.add_node( pos, { name = node_base_name.."_open", param2 = node.param2 } )
+		on_rightclick = function(pos, node)
+			minetest.add_node(pos, {
+				name = node_base_name.."_open",
+				param2 = node.param2
+			})
 		end,
 	})
 
 	-- add a craft receipe for the door
-	minetest.register_craft( {
+	minetest.register_craft({
 		output = node_base_name.."_closed",
 		recipe = {
 			{ material, '', material },
 			{ material, '', material },
 			{ material, '', material }
 		}
-	} )
+	})
 
 
 	-- Make doors reacts to mesecons
 	if minetest.get_modpath("mesecons") then
 		local mesecons = {
 			effector = {
-				action_on = function( pos, node )
-					minetest.add_node( pos, { name = node_base_name.."_open",   param2 = node.param2 } )
+				action_on = function(pos, node)
+					minetest.add_node(pos, {
+						name = node_base_name.."_open",
+						param2 = node.param2
+					})
 				end,
-				action_off = function( pos, node )
-					minetest.add_node( pos, { name = node_base_name.."_closed", param2 = node.param2 } )
+				action_off = function(pos, node)
+					minetest.add_node(pos, {
+						name = node_base_name.."_closed",
+						param2 = node.param2
+					})
 				end,
 				rules = mesecon.rules.pplate
 			}
 		}
 
-		minetest.override_item( node_base_name.."_closed", { mesecons = mesecons } )
-		minetest.override_item( node_base_name.."_open",   { mesecons = mesecons } )
+		minetest.override_item(node_base_name.."_closed", { mesecons=mesecons })
+		minetest.override_item(node_base_name.."_open",   { mesecons=mesecons })
 	end
 end
 
 -- actually register the doors
 -- (but only if the materials for them exist)
-if minetest.get_modpath( "default" ) then
-	travelnet.register_door( "travelnet:elevator_door_steel", { "default_stone.png" },                 "default:steel_ingot" )
-	travelnet.register_door( "travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass" )
-	travelnet.register_door( "travelnet:elevator_door_tin",   { "default_clay.png" },                  "default:tin_ingot" )
+if minetest.get_modpath("default") then
+	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },                 "default:steel_ingot")
+	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass")
+	travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },                  "default:tin_ingot")
 end

--- a/doors.lua
+++ b/doors.lua
@@ -6,7 +6,7 @@ local S = minetest.get_translator("travelnet")
 
 travelnet.register_door = function(node_base_name, def_tiles, material)
 
-	minetest.register_node(node_base_name.."_open", {
+	minetest.register_node(node_base_name .. "_open", {
 		description = S("elevator door (open)"),
 		drawtype = "nodebox",
 		-- top, bottom, side1, side2, inner, outer
@@ -37,16 +37,16 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 				{ -0.9, -0.5, 0.4, 0.9, 1.5, 0.5 },
 			},
 		},
-		drop = node_base_name.."_closed",
+		drop = node_base_name .. "_closed",
 		on_rightclick = function(pos, node)
 			minetest.add_node(pos, {
-				name = node_base_name.."_closed",
+				name = node_base_name .. "_closed",
 				param2 = node.param2
 			})
 		end,
 	})
 
-	minetest.register_node(node_base_name.."_closed", {
+	minetest.register_node(node_base_name .. "_closed", {
 		description = S("elevator door (closed)"),
 		drawtype = "nodebox",
 		-- top, bottom, side1, side2, inner, outer
@@ -75,7 +75,7 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 		},
 		on_rightclick = function(pos, node)
 			minetest.add_node(pos, {
-				name = node_base_name.."_open",
+				name = node_base_name .. "_open",
 				param2 = node.param2
 			})
 		end,
@@ -83,7 +83,7 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 
 	-- add a craft receipe for the door
 	minetest.register_craft({
-		output = node_base_name.."_closed",
+		output = node_base_name .. "_closed",
 		recipe = {
 			{ material, '', material },
 			{ material, '', material },
@@ -98,13 +98,13 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 			effector = {
 				action_on = function(pos, node)
 					minetest.add_node(pos, {
-						name = node_base_name.."_open",
+						name = node_base_name .. "_open",
 						param2 = node.param2
 					})
 				end,
 				action_off = function(pos, node)
 					minetest.add_node(pos, {
-						name = node_base_name.."_closed",
+						name = node_base_name .. "_closed",
 						param2 = node.param2
 					})
 				end,
@@ -112,8 +112,8 @@ travelnet.register_door = function(node_base_name, def_tiles, material)
 			}
 		}
 
-		minetest.override_item(node_base_name.."_closed", { mesecons=mesecons })
-		minetest.override_item(node_base_name.."_open",   { mesecons=mesecons })
+		minetest.override_item(node_base_name .. "_closed", { mesecons=mesecons })
+		minetest.override_item(node_base_name .. "_open",   { mesecons=mesecons })
 	end
 end
 

--- a/elevator.lua
+++ b/elevator.lua
@@ -3,27 +3,27 @@
 -- >utor: Sokomine
 local S = minetest.get_translator("travelnet")
 
-travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
+travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 	if not pos or not pos.x or not pos.z or not owner_name then
 		return
 	end
 
-	if not travelnet.targets[ owner_name ] then
-		minetest.chat_send_player( owner_name, S("Congratulations! This is your first elevator. "..
+	if not travelnet.targets[owner_name] then
+		minetest.chat_send_player(owner_name, S("Congratulations! This is your first elevator. "..
 			"You can build an elevator network by placing further elevators somewhere above "..
-			"or below this one. Just make sure that the x and z coordinate are the same.") )
+			"or below this one. Just make sure that the x and z coordinate are the same."))
 		return
 	end
 
-	local network_name = tostring( pos.x )..','..tostring( pos.z )
+	local network_name = tostring(pos.x)..','..tostring(pos.z)
 	-- will this be an elevator that will be added to an existing network?
-	if travelnet.targets[ owner_name ][ network_name ]
+	if travelnet.targets[owner_name][network_name]
 	-- does the network have any members at all?
-	and next( travelnet.targets[ owner_name ][ network_name ], nil ) then
-		minetest.chat_send_player( owner_name, S("This elevator will automaticly connect to the "..
+	and next(travelnet.targets[owner_name][network_name], nil) then
+		minetest.chat_send_player(owner_name, S("This elevator will automaticly connect to the "..
 			"other elevators you have placed at different heights. Just enter a station name "..
 			"and click on \"store\" to set it up. Or just punch it to set the height as station "..
-			"name.") )
+			"name."))
 		return
 	end
 
@@ -31,13 +31,13 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 	local nearest_dist = 100000000
 	local nearest_dist_x = 0
 	local nearest_dist_z = 0
-	for target_network_name, data in pairs( travelnet.targets[ owner_name ] ) do
-		local station_name = next( data, nil )
-		if station_name and data[ station_name ][ "nr" ] and data[ station_name ].pos then
-			local station_pos = data[ station_name ].pos
+	for target_network_name, data in pairs(travelnet.targets[owner_name]) do
+		local station_name = next(data, nil)
+		if station_name and data[station_name]["nr"] and data[station_name].pos then
+			local station_pos = data[station_name].pos
 			local dist = math.ceil(math.sqrt(
-					  ( station_pos.x - pos.x ) * ( station_pos.x - pos.x )
-					+ ( station_pos.z - pos.z ) * ( station_pos.z - pos.z )))
+					  (station_pos.x - pos.x) * (station_pos.x - pos.x)
+					+ (station_pos.z - pos.z) * (station_pos.z - pos.z)))
 			-- find the nearest one; store network_name and (minimal) distance
 			if dist < nearest_dist then
 				nearest_dist = dist
@@ -51,13 +51,13 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 		local text = S("Your nearest elevator network is located").." "
 		-- in front of/behind
 		if     (param2 == 0 and nearest_dist_z >= 0) or (param2 == 2 and nearest_dist_z <= 0) then
-			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m behind this elevator and")
+			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m behind this elevator and")
 		elseif (param2 == 1 and nearest_dist_x >= 0) or (param2 == 3 and nearest_dist_x <= 0) then
-			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m behind this elevator and")
+			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m behind this elevator and")
 		elseif (param2 == 0 and nearest_dist_z <  0) or (param2 == 2 and nearest_dist_z >  0) then
-			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m in front of this elevator and")
+			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m in front of this elevator and")
 		elseif (param2 == 1 and nearest_dist_x <  0) or (param2 == 3 and nearest_dist_x >  0) then
-			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m in front of this elevator and")
+			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m in front of this elevator and")
 		else
 			text = text..S(" ERROR")
 		end
@@ -65,26 +65,26 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 
 		-- right/left
 		if     (param2 == 0 and nearest_dist_x <  0) or (param2 == 2 and nearest_dist_x >  0) then
-			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m to the left")
+			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m to the left")
 		elseif (param2 == 1 and nearest_dist_z >= 0) or (param2 == 3 and nearest_dist_z <= 0) then
-			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m to the left")
+			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m to the left")
 		elseif (param2 == 0 and nearest_dist_x >= 0) or (param2 == 2 and nearest_dist_x <= 0) then
-			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m to the right")
+			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m to the right")
 		elseif (param2 == 1 and nearest_dist_z <  0) or (param2 == 3 and nearest_dist_z >  0) then
-			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m to the right")
+			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m to the right")
 		else
 			text = text..S(" ERROR")
 		end
 
-		minetest.chat_send_player( owner_name, text..
-			S(", located at x").."="..tostring( pos.x + nearest_dist_x )..
-			", z="..tostring( pos.z + nearest_dist_z )..
-			". "..S("This elevator here will start a new shaft/network.") )
+		minetest.chat_send_player(owner_name, text..
+			S(", located at x").."="..tostring(pos.x + nearest_dist_x)..
+			", z="..tostring(pos.z + nearest_dist_z)..
+			". "..S("This elevator here will start a new shaft/network."))
 	else
-		minetest.chat_send_player( owner_name, S("This is your first elevator. It differs from "..
+		minetest.chat_send_player(owner_name, S("This is your first elevator. It differs from "..
 			"travelnet networks by only allowing movement in vertical direction (up or down). "..
 			"All further elevators which you will place at the same x,z coordinates at differnt "..
-			"heights will be able to connect to this elevator.") )
+			"heights will be able to connect to this elevator."))
 	end
 end
 
@@ -96,7 +96,7 @@ minetest.register_node("travelnet:elevator", {
 	sunlight_propagates = true,
 	paramtype = 'light',
 	paramtype2 = "facedir",
-	wield_scale = { x = 0.6, y = 0.6, z = 0.6 },
+	wield_scale = { x=0.6, y=0.6, z=0.6 },
 
 	selection_box = {
 		type = "fixed",
@@ -125,35 +125,35 @@ minetest.register_node("travelnet:elevator", {
 
 	light_source = 10,
 
-	after_place_node  = function( pos, placer )
-		local meta = minetest.get_meta( pos )
-		meta:set_string( "infotext",       S("Elevator (unconfigured)") )
-		meta:set_string( "station_name",   "" )
-		meta:set_string( "station_network","" )
-		meta:set_string( "owner",          placer:get_player_name() )
+	after_place_node  = function(pos, placer)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("infotext",       S("Elevator (unconfigured)"))
+		meta:set_string("station_name",   "")
+		meta:set_string("station_network","")
+		meta:set_string("owner",          placer:get_player_name())
 		-- request initial data
-		meta:set_string( "formspec",
+		meta:set_string("formspec",
 			"size[12,10]"..
 			"field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
 			"button_exit[6.3,6.2;1.7,0.7;station_set;"..S("Store").."]"
 		)
 
-		local top_pos = { x = pos.x, y = pos.y+1, z = pos.z }
-		minetest.set_node( top_pos, {name="travelnet:hidden_top"} )
-		travelnet.show_nearest_elevator( pos, placer:get_player_name(), minetest.dir_to_facedir( placer:get_look_dir() ) )
+		local top_pos = { x=pos.x, y=pos.y+1, z=pos.z }
+		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
+		travelnet.show_nearest_elevator(pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()))
 	end,
 
 	on_receive_fields = travelnet.on_receive_fields,
-	on_punch = function( pos, _, puncher )
-		travelnet.update_formspec( pos, puncher:get_player_name() )
+	on_punch = function(pos, _, puncher)
+		travelnet.update_formspec(pos, puncher:get_player_name())
 	end,
 
-	can_dig = function( pos, player )
-		return travelnet.can_dig( pos, player, 'elevator' )
+	can_dig = function(pos, player)
+		return travelnet.can_dig(pos, player, 'elevator')
 	end,
 
-	after_dig_node = function( pos, oldnode, oldmetadata, digger )
-		travelnet.remove_box( pos, oldnode, oldmetadata, digger )
+	after_dig_node = function(pos, oldnode, oldmetadata, digger)
+		travelnet.remove_box(pos, oldnode, oldmetadata, digger)
 	end,
 
 	-- TNT and overenthusiastic DMs do not destroy elevators either
@@ -161,9 +161,9 @@ minetest.register_node("travelnet:elevator", {
 	end,
 
 	-- taken from VanessaEs homedecor fridge
-	on_place = function( itemstack, placer, pointed_thing )
+	on_place = function(itemstack, placer, pointed_thing)
 		local pos  = pointed_thing.above
-		local node = minetest.get_node({ x = pos.x, y = pos.y+1, z = pos.z })
+		local node = minetest.get_node({ x=pos.x, y=pos.y+1, z=pos.z })
 		local def = minetest.registered_nodes[node.name]
 		-- leftover top nodes can be removed by placing a new elevator underneath
 		if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
@@ -173,12 +173,12 @@ minetest.register_node("travelnet:elevator", {
 			)
 			return
 		end
-		return minetest.item_place( itemstack, placer, pointed_thing )
+		return minetest.item_place(itemstack, placer, pointed_thing)
 	end,
 
-	on_destruct = function( pos )
-		pos = { x = pos.x, y = pos.y+1, z = pos.z }
-		minetest.remove_node( pos )
+	on_destruct = function(pos)
+		pos = { x=pos.x, y=pos.y+1, z=pos.z }
+		minetest.remove_node(pos)
 	end
 })
 

--- a/elevator.lua
+++ b/elevator.lua
@@ -11,7 +11,7 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 	if not travelnet.targets[ owner_name ] then
 		minetest.chat_send_player( owner_name, S("Congratulations! This is your first elevator. "..
 			"You can build an elevator network by placing further elevators somewhere above "..
-			"or below this one. Just make sure that the x and z coordinate are the same."))
+			"or below this one. Just make sure that the x and z coordinate are the same.") )
 		return
 	end
 
@@ -23,7 +23,7 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 		minetest.chat_send_player( owner_name, S("This elevator will automaticly connect to the "..
 			"other elevators you have placed at different heights. Just enter a station name "..
 			"and click on \"store\" to set it up. Or just punch it to set the height as station "..
-			"name."))
+			"name.") )
 		return
 	end
 
@@ -50,41 +50,41 @@ travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
 	if nearest_name ~= "" then
 		local text = S("Your nearest elevator network is located").." "
 		-- in front of/behind
-		if (param2==0 and nearest_dist_z>=0) or (param2==2 and nearest_dist_z<=0) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m behind this elevator and")
-		elseif (param2==1 and nearest_dist_x>=0) or (param2==3 and nearest_dist_x<=0) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m behind this elevator and")
-		elseif (param2==0 and nearest_dist_z< 0) or (param2==2 and nearest_dist_z> 0) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m in front of this elevator and")
-		elseif (param2==1 and nearest_dist_x< 0) or (param2==3 and nearest_dist_x> 0) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m in front of this elevator and")
+		if     (param2 == 0 and nearest_dist_z >= 0) or (param2 == 2 and nearest_dist_z <= 0) then
+			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m behind this elevator and")
+		elseif (param2 == 1 and nearest_dist_x >= 0) or (param2 == 3 and nearest_dist_x <= 0) then
+			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m behind this elevator and")
+		elseif (param2 == 0 and nearest_dist_z <  0) or (param2 == 2 and nearest_dist_z >  0) then
+			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m in front of this elevator and")
+		elseif (param2 == 1 and nearest_dist_x <  0) or (param2 == 3 and nearest_dist_x >  0) then
+			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m in front of this elevator and")
 		else
 			text = text..S(" ERROR")
 		end
 		text = text.." "
 
 		-- right/left
-		if (param2==0 and nearest_dist_x< 0)or (param2==2 and nearest_dist_x> 0) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the left")
-		elseif (param2==1 and nearest_dist_z>=0)or (param2==3 and nearest_dist_z<=0) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the left")
-		elseif (param2==0 and nearest_dist_x>=0)or (param2==2 and nearest_dist_x<=0) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the right")
-		elseif (param2==1 and nearest_dist_z< 0)or (param2==3 and nearest_dist_z> 0) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the right")
+		if     (param2 == 0 and nearest_dist_x <  0) or (param2 == 2 and nearest_dist_x >  0) then
+			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m to the left")
+		elseif (param2 == 1 and nearest_dist_z >= 0) or (param2 == 3 and nearest_dist_z <= 0) then
+			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m to the left")
+		elseif (param2 == 0 and nearest_dist_x >= 0) or (param2 == 2 and nearest_dist_x <= 0) then
+			text = text..tostring( math.abs(nearest_dist_x ) ).." "..S("m to the right")
+		elseif (param2 == 1 and nearest_dist_z <  0) or (param2 == 3 and nearest_dist_z >  0) then
+			text = text..tostring( math.abs(nearest_dist_z ) ).." "..S("m to the right")
 		else
 			text = text..S(" ERROR")
 		end
 
 		minetest.chat_send_player( owner_name, text..
-			S(", located at x").."="..tostring( pos.x+nearest_dist_x)..
-			", z="..tostring( pos.z+nearest_dist_z)..
-			". "..S("This elevator here will start a new shaft/network."))
+			S(", located at x").."="..tostring( pos.x + nearest_dist_x )..
+			", z="..tostring( pos.z + nearest_dist_z )..
+			". "..S("This elevator here will start a new shaft/network.") )
 	else
 		minetest.chat_send_player( owner_name, S("This is your first elevator. It differs from "..
 			"travelnet networks by only allowing movement in vertical direction (up or down). "..
 			"All further elevators which you will place at the same x,z coordinates at differnt "..
-			"heights will be able to connect to this elevator."))
+			"heights will be able to connect to this elevator.") )
 	end
 end
 
@@ -96,7 +96,7 @@ minetest.register_node("travelnet:elevator", {
 	sunlight_propagates = true,
 	paramtype = 'light',
 	paramtype2 = "facedir",
-	wield_scale = {x=0.6, y=0.6, z=0.6},
+	wield_scale = { x = 0.6, y = 0.6, z = 0.6 },
 
 	selection_box = {
 		type = "fixed",
@@ -125,34 +125,34 @@ minetest.register_node("travelnet:elevator", {
 
 	light_source = 10,
 
-	after_place_node  = function(pos, placer)
-		local meta = minetest.get_meta(pos)
-		meta:set_string("infotext",       S("Elevator (unconfigured)"))
-		meta:set_string("station_name",   "")
-		meta:set_string("station_network","")
-		meta:set_string("owner",          placer:get_player_name() )
+	after_place_node  = function( pos, placer )
+		local meta = minetest.get_meta( pos )
+		meta:set_string( "infotext",       S("Elevator (unconfigured)") )
+		meta:set_string( "station_name",   "" )
+		meta:set_string( "station_network","" )
+		meta:set_string( "owner",          placer:get_player_name() )
 		-- request initial data
-		meta:set_string("formspec",
+		meta:set_string( "formspec",
 			"size[12,10]"..
 			"field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
 			"button_exit[6.3,6.2;1.7,0.7;station_set;"..S("Store").."]"
 		)
 
-		local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
-		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
-		travelnet.show_nearest_elevator( pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()))
+		local top_pos = { x = pos.x, y = pos.y+1, z = pos.z }
+		minetest.set_node( top_pos, {name="travelnet:hidden_top"} )
+		travelnet.show_nearest_elevator( pos, placer:get_player_name(), minetest.dir_to_facedir( placer:get_look_dir() ) )
 	end,
 
 	on_receive_fields = travelnet.on_receive_fields,
-	on_punch = function(pos, _, puncher)
-		travelnet.update_formspec(pos, puncher:get_player_name())
+	on_punch = function( pos, _, puncher )
+		travelnet.update_formspec( pos, puncher:get_player_name() )
 	end,
 
 	can_dig = function( pos, player )
 		return travelnet.can_dig( pos, player, 'elevator' )
 	end,
 
-	after_dig_node = function(pos, oldnode, oldmetadata, digger)
+	after_dig_node = function( pos, oldnode, oldmetadata, digger )
 		travelnet.remove_box( pos, oldnode, oldmetadata, digger )
 	end,
 
@@ -161,9 +161,9 @@ minetest.register_node("travelnet:elevator", {
 	end,
 
 	-- taken from VanessaEs homedecor fridge
-	on_place = function(itemstack, placer, pointed_thing)
+	on_place = function( itemstack, placer, pointed_thing )
 		local pos  = pointed_thing.above
-		local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
+		local node = minetest.get_node({ x = pos.x, y = pos.y+1, z = pos.z })
 		local def = minetest.registered_nodes[node.name]
 		-- leftover top nodes can be removed by placing a new elevator underneath
 		if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
@@ -173,12 +173,12 @@ minetest.register_node("travelnet:elevator", {
 			)
 			return
 		end
-		return minetest.item_place(itemstack, placer, pointed_thing)
+		return minetest.item_place( itemstack, placer, pointed_thing )
 	end,
 
-	on_destruct = function(pos)
-		pos = {x=pos.x, y=pos.y+1, z=pos.z}
-		minetest.remove_node(pos)
+	on_destruct = function( pos )
+		pos = { x = pos.x, y = pos.y+1, z = pos.z }
+		minetest.remove_node( pos )
 	end
 })
 

--- a/elevator.lua
+++ b/elevator.lua
@@ -9,21 +9,24 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 	end
 
 	if not travelnet.targets[owner_name] then
-		minetest.chat_send_player(owner_name, S("Congratulations! This is your first elevator. "..
-			"You can build an elevator network by placing further elevators somewhere above "..
-			"or below this one. Just make sure that the x and z coordinate are the same."))
+		minetest.chat_send_player(owner_name,
+				S("Congratulations! This is your first elevator. "..
+					"You can build an elevator network by placing further elevators somewhere above "..
+					"or below this one. Just make sure that the x and z coordinate are the same."))
 		return
 	end
 
-	local network_name = tostring(pos.x)..','..tostring(pos.z)
+	local network_name = tostring(pos.x) .. ',' .. tostring(pos.z)
 	-- will this be an elevator that will be added to an existing network?
-	if travelnet.targets[owner_name][network_name]
-	-- does the network have any members at all?
-	and next(travelnet.targets[owner_name][network_name], nil) then
-		minetest.chat_send_player(owner_name, S("This elevator will automaticly connect to the "..
-			"other elevators you have placed at different heights. Just enter a station name "..
-			"and click on \"store\" to set it up. Or just punch it to set the height as station "..
-			"name."))
+	if	    travelnet.targets[owner_name][network_name]
+		-- does the network have any members at all?
+		and next(travelnet.targets[owner_name][network_name], nil)
+	then
+		minetest.chat_send_player(owner_name,
+				S("This elevator will automaticly connect to the "..
+					"other elevators you have placed at different heights. Just enter a station name "..
+					"and click on \"store\" to set it up. Or just punch it to set the height as station "..
+					"name."))
 		return
 	end
 
@@ -48,43 +51,44 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 		end
 	end
 	if nearest_name ~= "" then
-		local text = S("Your nearest elevator network is located").." "
+		local text = S("Your nearest elevator network is located") .. " "
 		-- in front of/behind
 		if     (param2 == 0 and nearest_dist_z >= 0) or (param2 == 2 and nearest_dist_z <= 0) then
-			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m behind this elevator and")
+			text = text .. tostring(math.abs(nearest_dist_z)) .. " " .. S("m behind this elevator and")
 		elseif (param2 == 1 and nearest_dist_x >= 0) or (param2 == 3 and nearest_dist_x <= 0) then
-			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m behind this elevator and")
+			text = text .. tostring(math.abs(nearest_dist_x)) .. " " .. S("m behind this elevator and")
 		elseif (param2 == 0 and nearest_dist_z <  0) or (param2 == 2 and nearest_dist_z >  0) then
-			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m in front of this elevator and")
+			text = text .. tostring(math.abs(nearest_dist_z)) .. " " .. S("m in front of this elevator and")
 		elseif (param2 == 1 and nearest_dist_x <  0) or (param2 == 3 and nearest_dist_x >  0) then
-			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m in front of this elevator and")
+			text = text .. tostring(math.abs(nearest_dist_x)) .. " " .. S("m in front of this elevator and")
 		else
-			text = text..S(" ERROR")
+			text = text .. S(" ERROR")
 		end
 		text = text.." "
 
 		-- right/left
 		if     (param2 == 0 and nearest_dist_x <  0) or (param2 == 2 and nearest_dist_x >  0) then
-			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m to the left")
+			text = text .. tostring(math.abs(nearest_dist_x)) .. " " .. S("m to the left")
 		elseif (param2 == 1 and nearest_dist_z >= 0) or (param2 == 3 and nearest_dist_z <= 0) then
-			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m to the left")
+			text = text .. tostring(math.abs(nearest_dist_z)) .. " " .. S("m to the left")
 		elseif (param2 == 0 and nearest_dist_x >= 0) or (param2 == 2 and nearest_dist_x <= 0) then
-			text = text..tostring(math.abs(nearest_dist_x)).." "..S("m to the right")
+			text = text .. tostring(math.abs(nearest_dist_x)) .. " " .. S("m to the right")
 		elseif (param2 == 1 and nearest_dist_z <  0) or (param2 == 3 and nearest_dist_z >  0) then
-			text = text..tostring(math.abs(nearest_dist_z)).." "..S("m to the right")
+			text = text .. tostring(math.abs(nearest_dist_z)) .. " " .. S("m to the right")
 		else
-			text = text..S(" ERROR")
+			text = text .. S(" ERROR")
 		end
 
-		minetest.chat_send_player(owner_name, text..
-			S(", located at x").."="..tostring(pos.x + nearest_dist_x)..
-			", z="..tostring(pos.z + nearest_dist_z)..
-			". "..S("This elevator here will start a new shaft/network."))
+		minetest.chat_send_player(owner_name, text ..
+				S(", located at x") .. "=" .. tostring(pos.x + nearest_dist_x) ..
+				", z=" .. tostring(pos.z + nearest_dist_z) ..
+				". " .. S("This elevator here will start a new shaft/network."))
 	else
-		minetest.chat_send_player(owner_name, S("This is your first elevator. It differs from "..
-			"travelnet networks by only allowing movement in vertical direction (up or down). "..
-			"All further elevators which you will place at the same x,z coordinates at differnt "..
-			"heights will be able to connect to this elevator."))
+		minetest.chat_send_player(owner_name,
+				S("This is your first elevator. It differs from " ..
+					"travelnet networks by only allowing movement in vertical direction (up or down). " ..
+					"All further elevators which you will place at the same x,z coordinates at differnt " ..
+					"heights will be able to connect to this elevator."))
 	end
 end
 
@@ -133,13 +137,13 @@ minetest.register_node("travelnet:elevator", {
 		meta:set_string("owner",          placer:get_player_name())
 		-- request initial data
 		meta:set_string("formspec",
-			"size[12,10]"..
-			"field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
-			"button_exit[6.3,6.2;1.7,0.7;station_set;"..S("Store").."]"
+			"size[12,10]" ..
+			"field[0.3,5.6;6,0.7;station_name;" .. S("Name of this station:") .. ";]" ..
+			"button_exit[6.3,6.2;1.7,0.7;station_set;" .. S("Store") .. "]"
 		)
 
 		local top_pos = { x=pos.x, y=pos.y+1, z=pos.z }
-		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
+		minetest.set_node(top_pos, { name="travelnet:hidden_top" })
 		travelnet.show_nearest_elevator(pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()))
 	end,
 

--- a/elevator.lua
+++ b/elevator.lua
@@ -16,7 +16,7 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 		return
 	end
 
-	local network_name = tostring(pos.x) .. ',' .. tostring(pos.z)
+	local network_name = tostring(pos.x) .. "," .. tostring(pos.z)
 	-- will this be an elevator that will be added to an existing network?
 	if	    travelnet.targets[owner_name][network_name]
 		-- does the network have any members at all?
@@ -98,7 +98,7 @@ minetest.register_node("travelnet:elevator", {
 	drawtype = "mesh",
 	mesh = "travelnet_elevator.obj",
 	sunlight_propagates = true,
-	paramtype = 'light',
+	paramtype = "light",
 	paramtype2 = "facedir",
 	wield_scale = { x=0.6, y=0.6, z=0.6 },
 
@@ -153,7 +153,7 @@ minetest.register_node("travelnet:elevator", {
 	end,
 
 	can_dig = function(pos, player)
-		return travelnet.can_dig(pos, player, 'elevator')
+		return travelnet.can_dig(pos, player, "elevator")
 	end,
 
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -173,7 +173,7 @@ minetest.register_node("travelnet:elevator", {
 		if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
 			minetest.chat_send_player(
 				placer:get_player_name(),
-				S('Not enough vertical space to place the travelnet box!')
+				S("Not enough vertical space to place the travelnet box!")
 			)
 			return
 		end

--- a/elevator.lua
+++ b/elevator.lua
@@ -10,8 +10,8 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 
 	if not travelnet.targets[owner_name] then
 		minetest.chat_send_player(owner_name,
-				S("Congratulations! This is your first elevator. "..
-					"You can build an elevator network by placing further elevators somewhere above "..
+				S("Congratulations! This is your first elevator. " ..
+					"You can build an elevator network by placing further elevators somewhere above " ..
 					"or below this one. Just make sure that the x and z coordinate are the same."))
 		return
 	end
@@ -23,9 +23,9 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 		and next(travelnet.targets[owner_name][network_name], nil)
 	then
 		minetest.chat_send_player(owner_name,
-				S("This elevator will automaticly connect to the "..
-					"other elevators you have placed at different heights. Just enter a station name "..
-					"and click on \"store\" to set it up. Or just punch it to set the height as station "..
+				S("This elevator will automaticly connect to the " ..
+					"other elevators you have placed at different heights. Just enter a station name " ..
+					"and click on \"store\" to set it up. Or just punch it to set the height as station " ..
 					"name."))
 		return
 	end
@@ -64,7 +64,7 @@ travelnet.show_nearest_elevator = function(pos, owner_name, param2)
 		else
 			text = text .. S(" ERROR")
 		end
-		text = text.." "
+		text = text .. " "
 
 		-- right/left
 		if     (param2 == 0 and nearest_dist_x <  0) or (param2 == 2 and nearest_dist_x >  0) then

--- a/elevator.lua
+++ b/elevator.lua
@@ -4,85 +4,87 @@
 local S = minetest.get_translator("travelnet")
 
 travelnet.show_nearest_elevator = function( pos, owner_name, param2 )
-	if( not( pos ) or not(pos.x) or not(pos.z) or not( owner_name )) then
-		return;
+	if not pos or not pos.x or not pos.z or not owner_name then
+		return
 	end
 
-	if( not( travelnet.targets[ owner_name ] )) then
+	if not travelnet.targets[ owner_name ] then
 		minetest.chat_send_player( owner_name, S("Congratulations! This is your first elevator. "..
 			"You can build an elevator network by placing further elevators somewhere above "..
-			"or below this one. Just make sure that the x and z coordinate are the same."));
-		return;
+			"or below this one. Just make sure that the x and z coordinate are the same."))
+		return
 	end
 
-	local network_name = tostring( pos.x )..','..tostring( pos.z );
+	local network_name = tostring( pos.x )..','..tostring( pos.z )
 	-- will this be an elevator that will be added to an existing network?
-	if( travelnet.targets[ owner_name ][ network_name ]
-	  -- does the network have any members at all?
-	  and next( travelnet.targets[ owner_name ][ network_name ], nil )) then
+	if travelnet.targets[ owner_name ][ network_name ]
+	-- does the network have any members at all?
+	and next( travelnet.targets[ owner_name ][ network_name ], nil ) then
 		minetest.chat_send_player( owner_name, S("This elevator will automaticly connect to the "..
 			"other elevators you have placed at different heights. Just enter a station name "..
 			"and click on \"store\" to set it up. Or just punch it to set the height as station "..
-			"name."));
-		return;
+			"name."))
+		return
 	end
 
-	local nearest_name = "";
-	local nearest_dist = 100000000;
-	local nearest_dist_x = 0;
-	local nearest_dist_z = 0;
+	local nearest_name = ""
+	local nearest_dist = 100000000
+	local nearest_dist_x = 0
+	local nearest_dist_z = 0
 	for target_network_name, data in pairs( travelnet.targets[ owner_name ] ) do
-		local station_name = next( data, nil );
-		if( station_name and data[ station_name ][ "nr" ] and data[ station_name ].pos) then
-			local station_pos = data[ station_name ].pos;
+		local station_name = next( data, nil )
+		if station_name and data[ station_name ][ "nr" ] and data[ station_name ].pos then
+			local station_pos = data[ station_name ].pos
 			local dist = math.ceil(math.sqrt(
 					  ( station_pos.x - pos.x ) * ( station_pos.x - pos.x )
-					+ ( station_pos.z - pos.z ) * ( station_pos.z - pos.z )));
+					+ ( station_pos.z - pos.z ) * ( station_pos.z - pos.z )))
 			-- find the nearest one; store network_name and (minimal) distance
-			if( dist < nearest_dist ) then
-				nearest_dist = dist;
-				nearest_dist_x = station_pos.x - pos.x;
-				nearest_dist_z = station_pos.z - pos.z;
-				nearest_name = target_network_name;
+			if dist < nearest_dist then
+				nearest_dist = dist
+				nearest_dist_x = station_pos.x - pos.x
+				nearest_dist_z = station_pos.z - pos.z
+				nearest_name = target_network_name
 			end
 		end
 	end
-	if( nearest_name ~= "" ) then
-		local text = S("Your nearest elevator network is located").." ";
+	if nearest_name ~= "" then
+		local text = S("Your nearest elevator network is located").." "
 		-- in front of/behind
-		if(    (param2==0 and nearest_dist_z>=0)or (param2==2 and nearest_dist_z<=0)) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m behind this elevator and");
-		elseif((param2==1 and nearest_dist_x>=0)or (param2==3 and nearest_dist_x<=0)) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m behind this elevator and");
-		elseif((param2==0 and nearest_dist_z< 0)or (param2==2 and nearest_dist_z> 0)) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m in front of this elevator and");
-		elseif((param2==1 and nearest_dist_x< 0)or (param2==3 and nearest_dist_x> 0)) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m in front of this elevator and");
-		else text = text..S(" ERROR");
+		if (param2==0 and nearest_dist_z>=0) or (param2==2 and nearest_dist_z<=0) then
+			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m behind this elevator and")
+		elseif (param2==1 and nearest_dist_x>=0) or (param2==3 and nearest_dist_x<=0) then
+			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m behind this elevator and")
+		elseif (param2==0 and nearest_dist_z< 0) or (param2==2 and nearest_dist_z> 0) then
+			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m in front of this elevator and")
+		elseif (param2==1 and nearest_dist_x< 0) or (param2==3 and nearest_dist_x> 0) then
+			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m in front of this elevator and")
+		else
+			text = text..S(" ERROR")
 		end
-		text = text.." ";
+		text = text.." "
 
 		-- right/left
-		if(    (param2==0 and nearest_dist_x< 0)or (param2==2 and nearest_dist_x> 0)) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the left");
-		elseif((param2==1 and nearest_dist_z>=0)or (param2==3 and nearest_dist_z<=0)) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the left");
-		elseif((param2==0 and nearest_dist_x>=0)or (param2==2 and nearest_dist_x<=0)) then
-			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the right");
-		elseif((param2==1 and nearest_dist_z< 0)or (param2==3 and nearest_dist_z> 0)) then
-			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the right");
-		else text = text..S(" ERROR");
+		if (param2==0 and nearest_dist_x< 0)or (param2==2 and nearest_dist_x> 0) then
+			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the left")
+		elseif (param2==1 and nearest_dist_z>=0)or (param2==3 and nearest_dist_z<=0) then
+			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the left")
+		elseif (param2==0 and nearest_dist_x>=0)or (param2==2 and nearest_dist_x<=0) then
+			text = text..tostring( math.abs(nearest_dist_x )).." "..S("m to the right")
+		elseif (param2==1 and nearest_dist_z< 0)or (param2==3 and nearest_dist_z> 0) then
+			text = text..tostring( math.abs(nearest_dist_z )).." "..S("m to the right")
+		else
+			text = text..S(" ERROR")
 		end
 
 		minetest.chat_send_player( owner_name, text..
 			S(", located at x").."="..tostring( pos.x+nearest_dist_x)..
 			", z="..tostring( pos.z+nearest_dist_z)..
-			". "..S("This elevator here will start a new shaft/network."));
+			". "..S("This elevator here will start a new shaft/network."))
 	else
 		minetest.chat_send_player( owner_name, S("This is your first elevator. It differs from "..
 			"travelnet networks by only allowing movement in vertical direction (up or down). "..
 			"All further elevators which you will place at the same x,z coordinates at differnt "..
-			"heights will be able to connect to this elevator."));
+			"heights will be able to connect to this elevator."))
 	end
 end
 
@@ -124,25 +126,25 @@ minetest.register_node("travelnet:elevator", {
 	light_source = 10,
 
 	after_place_node  = function(pos, placer)
-		local meta = minetest.get_meta(pos);
-		meta:set_string("infotext",       S("Elevator (unconfigured)"));
-		meta:set_string("station_name",   "");
-		meta:set_string("station_network","");
-		meta:set_string("owner",          placer:get_player_name() );
+		local meta = minetest.get_meta(pos)
+		meta:set_string("infotext",       S("Elevator (unconfigured)"))
+		meta:set_string("station_name",   "")
+		meta:set_string("station_network","")
+		meta:set_string("owner",          placer:get_player_name() )
 		-- request initial data
 		meta:set_string("formspec",
 			"size[12,10]"..
 			"field[0.3,5.6;6,0.7;station_name;"..S("Name of this station:")..";]"..
 			"button_exit[6.3,6.2;1.7,0.7;station_set;"..S("Store").."]"
-		);
+		)
 
 		local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
 		minetest.set_node(top_pos, {name="travelnet:hidden_top"})
-		travelnet.show_nearest_elevator( pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()));
+		travelnet.show_nearest_elevator( pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()))
 	end,
 
 	on_receive_fields = travelnet.on_receive_fields,
-	on_punch          = function(pos, _, puncher)
+	on_punch = function(pos, _, puncher)
 		travelnet.update_formspec(pos, puncher:get_player_name())
 	end,
 
@@ -160,8 +162,8 @@ minetest.register_node("travelnet:elevator", {
 
 	-- taken from VanessaEs homedecor fridge
 	on_place = function(itemstack, placer, pointed_thing)
-		local pos  = pointed_thing.above;
-		local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z});
+		local pos  = pointed_thing.above
+		local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
 		local def = minetest.registered_nodes[node.name]
 		-- leftover top nodes can be removed by placing a new elevator underneath
 		if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
@@ -169,14 +171,14 @@ minetest.register_node("travelnet:elevator", {
 				placer:get_player_name(),
 				S('Not enough vertical space to place the travelnet box!')
 			)
-			return;
+			return
 		end
-		return minetest.item_place(itemstack, placer, pointed_thing);
+		return minetest.item_place(itemstack, placer, pointed_thing)
 	end,
 
 	on_destruct = function(pos)
-	pos = {x=pos.x, y=pos.y+1, z=pos.z}
-	minetest.remove_node(pos)
+		pos = {x=pos.x, y=pos.y+1, z=pos.z}
+		minetest.remove_node(pos)
 	end
 })
 

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -65,16 +65,18 @@ travelnet.reset_formspec = function(meta)
 
 	-- request initinal data
 	meta:set_string("formspec",
-			"size[10,6.0]"..
-			"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
-			"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
-			"field[0.3,1.2;9,0.9;station_name;"..S("Name of this station")..":;]"..
-			"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
-
-			"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape(station_network or "").."]"..
-			"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
-			"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
-			"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
-			"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
-			"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
+			"size[10,6.0]" ..
+			"label[2.0,0.0;--> " .. S("Configure this travelnet station") .. " <--]" ..
+			"button_exit[8.0,0.0;2.2,0.7;station_dig;" .. S("Remove station") .. "]" ..
+			"field[0.3,1.2;9,0.9;station_name;" .. S("Name of this station") .. ":;]" ..
+			"label[0.3,1.5;" ..
+				S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...") .. "]" ..
+			"field[0.3,2.8;9,0.9;station_network;" ..
+				S("Assign to Network:") .. ";" .. minetest.formspec_escape(station_network or "") .. "]" ..
+			"label[0.3,3.1;" ..
+				S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]" ..
+			"field[0.3,4.4;9,0.9;owner;" .. S("Owned by:") .. ";]" ..
+			"label[0.3,4.7;" .. S("Unless you know what you are doing, leave this empty.") .. "]" ..
+			"button_exit[3.8,5.3;1.7,0.7;station_set;" .. S("Save") .. "]" ..
+			"button_exit[6.3,5.3;1.7,0.7;station_exit;" .. S("Exit") .. "]")
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -5,12 +5,12 @@ travelnet.show_message = function(pos, player_name, title, message)
 	if not pos or not player_name or not message then
 		return
 	end
-	local formspec = "size[8,3]"..
-		"label[3,0;"..minetest.formspec_escape(title or S("Error")).."]"..
-		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape(message or "- nothing -")..";]"..
-		"button_exit[3.5,2.5;1.0,0.5;back;"..S("Back").."]"..
-		"button_exit[6.8,2.5;1.0,0.5;station_exit;"..S("Exit").."]"..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string(pos).."]"
+	local formspec = "size[8,3]" ..
+		"label[3,0;" .. minetest.formspec_escape(title or S("Error")) .. "]" ..
+		"textlist[0,0.5;8,1.5;;" .. minetest.formspec_escape(message or "- nothing -") .. ";]" ..
+		"button_exit[3.5,2.5;1.0,0.5;back;" .. S("Back") .. "]" ..
+		"button_exit[6.8,2.5;1.0,0.5;station_exit;" .. S("Exit") .. "]" ..
+		"field[20,20;0.1,0.1;pos2str;Pos;" .. minetest.pos_to_string(pos) .. "]"
 	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
 
@@ -21,8 +21,8 @@ travelnet.show_current_formspec = function(pos, meta, player_name)
 		return
 	end
 	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string("formspec")..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string(pos).."]"
+	local formspec = meta:get_string("formspec") ..
+		"field[20,20;0.1,0.1;pos2str;Pos;" .. minetest.pos_to_string(pos) .. "]"
 	-- show the formspec manually
 	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
@@ -51,7 +51,6 @@ end
 minetest.register_on_player_receive_fields(travelnet.form_input_handler)
 
 
-
 travelnet.reset_formspec = function(meta)
 	if not meta then
 		return
@@ -66,16 +65,16 @@ travelnet.reset_formspec = function(meta)
 
 	-- request initinal data
 	meta:set_string("formspec",
-		"size[10,6.0]"..
-		"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
-		"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
-		"field[0.3,1.2;9,0.9;station_name;"..S("Name of this station")..":;]"..
-		"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
+			"size[10,6.0]"..
+			"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
+			"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
+			"field[0.3,1.2;9,0.9;station_name;"..S("Name of this station")..":;]"..
+			"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
 
-		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape(station_network or "").."]"..
-		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
-		"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
-		"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
-		"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
-		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
+			"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape(station_network or "").."]"..
+			"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
+			"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
+			"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
+			"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
+			"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -1,81 +1,81 @@
 local S = minetest.get_translator("travelnet")
 
 -- minetest.chat_send_player is sometimes not so well visible
-travelnet.show_message = function( pos, player_name, title, message )
+travelnet.show_message = function(pos, player_name, title, message)
 	if not pos or not player_name or not message then
 		return
 	end
 	local formspec = "size[8,3]"..
-		"label[3,0;"..minetest.formspec_escape( title or S("Error") ).."]"..
-		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape( message or "- nothing -" )..";]"..
+		"label[3,0;"..minetest.formspec_escape(title or S("Error")).."]"..
+		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape(message or "- nothing -")..";]"..
 		"button_exit[3.5,2.5;1.0,0.5;back;"..S("Back").."]"..
 		"button_exit[6.8,2.5;1.0,0.5;station_exit;"..S("Exit").."]"..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
-	minetest.show_formspec( player_name, "travelnet:show", formspec )
+		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string(pos).."]"
+	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
 
 -- show the player the formspec he would see when right-clicking the node;
 -- needs to be simulated this way as calling on_rightclick would not do
-travelnet.show_current_formspec = function( pos, meta, player_name )
+travelnet.show_current_formspec = function(pos, meta, player_name)
 	if not pos or not meta or not player_name then
 		return
 	end
 	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string( "formspec" )..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
+	local formspec = meta:get_string("formspec")..
+		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string(pos).."]"
 	-- show the formspec manually
-	minetest.show_formspec( player_name, "travelnet:show", formspec )
+	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
 
 -- a player clicked on something in the formspec hse was manually shown
 -- (back from help page, moved travelnet up or down etc.)
-travelnet.form_input_handler = function( player, formname, fields)
+travelnet.form_input_handler = function(player, formname, fields)
 	if formname == "travelnet:show" and fields and fields.pos2str then
-		local pos = minetest.string_to_pos( fields.pos2str )
+		local pos = minetest.string_to_pos(fields.pos2str)
 		if not pos then
 			return
 		end
 
 		-- back button leads back to the main menu
 		if fields.back and fields.back ~= "" then
-			return travelnet.show_current_formspec( pos,
-					minetest.get_meta( pos ), player:get_player_name() )
+			return travelnet.show_current_formspec(pos,
+					minetest.get_meta(pos), player:get_player_name())
 		end
-		return travelnet.on_receive_fields( pos, formname, fields, player )
+		return travelnet.on_receive_fields(pos, formname, fields, player)
 	end
 end
 
 -- most formspecs the travelnet uses are stored in the travelnet node itself,
 -- but some may require some "back"-button functionality (i.e. help page,
 -- move up/down etc.)
-minetest.register_on_player_receive_fields( travelnet.form_input_handler )
+minetest.register_on_player_receive_fields(travelnet.form_input_handler)
 
 
 
-travelnet.reset_formspec = function( meta )
+travelnet.reset_formspec = function(meta)
 	if not meta then
 		return
 	end
-	meta:set_string( "infotext",       S("Travelnet-box (unconfigured)") )
-	meta:set_string( "station_name",   "" )
-	meta:set_string( "station_network","" )
-	meta:set_string( "owner",          "" )
+	meta:set_string("infotext",       S("Travelnet-box (unconfigured)"))
+	meta:set_string("station_name",   "")
+	meta:set_string("station_network","")
+	meta:set_string("owner",          "")
 	-- some players seem to be confused with entering network names at first; provide them
 	-- with a default name
 	local station_network = "net1"
 
 	-- request initinal data
-	meta:set_string( "formspec",
+	meta:set_string("formspec",
 		"size[10,6.0]"..
 		"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
 		"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
 		"field[0.3,1.2;9,0.9;station_name;"..S("Name of this station")..":;]"..
 		"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
 
-		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape( station_network or "" ).."]"..
-		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring( station_network )) .. ".]"..
+		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape(station_network or "").."]"..
+		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
 		"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
 		"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
 		"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
-		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]" )
+		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -2,70 +2,70 @@ local S = minetest.get_translator("travelnet")
 
 -- minetest.chat_send_player is sometimes not so well visible
 travelnet.show_message = function( pos, player_name, title, message )
-	if( not( pos ) or not( player_name ) or not( message )) then
-		return;
+	if not pos or not player_name or not message then
+		return
 	end
 	local formspec = "size[8,3]"..
 		"label[3,0;"..minetest.formspec_escape( title or S("Error")).."]"..
 		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape( message or "- nothing -")..";]"..
 		"button_exit[3.5,2.5;1.0,0.5;back;"..S("Back").."]"..
 		"button_exit[6.8,2.5;1.0,0.5;station_exit;"..S("Exit").."]"..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]";
-	minetest.show_formspec(player_name, "travelnet:show", formspec);
+		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
+	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
 
 -- show the player the formspec he would see when right-clicking the node;
 -- needs to be simulated this way as calling on_rightclick would not do
 travelnet.show_current_formspec = function( pos, meta, player_name )
-	if( not( pos ) or not( meta ) or not( player_name )) then
-		return;
+	if not pos or not meta or not player_name then
+		return
 	end
 	-- we need to supply the position of the travelnet box
 	local formspec = meta:get_string("formspec")..
-		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]";
+		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
 	-- show the formspec manually
-	minetest.show_formspec(player_name, "travelnet:show", formspec);
+	minetest.show_formspec(player_name, "travelnet:show", formspec)
 end
 
--- a player clicked on something in the formspec he was manually shown
+-- a player clicked on something in the formspec hse was manually shown
 -- (back from help page, moved travelnet up or down etc.)
 travelnet.form_input_handler = function( player, formname, fields)
-        if(formname == "travelnet:show" and fields and fields.pos2str) then
-		local pos = minetest.string_to_pos( fields.pos2str );
+	if formname == "travelnet:show" and fields and fields.pos2str then
+		local pos = minetest.string_to_pos( fields.pos2str )
 		if not pos then
 			return
 		end
 
 		-- back button leads back to the main menu
-		if( fields.back and fields.back ~= "" ) then
+		if fields.back and fields.back ~= "" then
 			return travelnet.show_current_formspec( pos,
-					minetest.get_meta( pos ), player:get_player_name());
+					minetest.get_meta( pos ), player:get_player_name())
 		end
-		return travelnet.on_receive_fields(pos, formname, fields, player);
-        end
+		return travelnet.on_receive_fields(pos, formname, fields, player)
+	end
 end
 
 -- most formspecs the travelnet uses are stored in the travelnet node itself,
 -- but some may require some "back"-button functionality (i.e. help page,
 -- move up/down etc.)
-minetest.register_on_player_receive_fields( travelnet.form_input_handler );
+minetest.register_on_player_receive_fields( travelnet.form_input_handler )
 
 
 
 travelnet.reset_formspec = function( meta )
-      if( not( meta )) then
-         return;
-      end
-      meta:set_string("infotext",       S("Travelnet-box (unconfigured)"));
-      meta:set_string("station_name",   "");
-      meta:set_string("station_network","");
-      meta:set_string("owner",          "");
-      -- some players seem to be confused with entering network names at first; provide them
-      -- with a default name
-			local station_network = "net1";
+	if not meta then
+		return
+	end
+	meta:set_string("infotext",       S("Travelnet-box (unconfigured)"))
+	meta:set_string("station_name",   "")
+	meta:set_string("station_network","")
+	meta:set_string("owner",          "")
+	-- some players seem to be confused with entering network names at first; provide them
+	-- with a default name
+	local station_network = "net1"
 
-      -- request initinal data
-      meta:set_string("formspec",
+	-- request initinal data
+	meta:set_string("formspec",
 		"size[10,6.0]"..
 		"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
 		"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
@@ -73,10 +73,10 @@ travelnet.reset_formspec = function( meta )
 		"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
 
 		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..
-			minetest.formspec_escape(station_network or "").."]"..
+		minetest.formspec_escape(station_network or "").."]"..
 		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
 		"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
 		"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
 		"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
-		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]");
+		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -6,12 +6,12 @@ travelnet.show_message = function( pos, player_name, title, message )
 		return
 	end
 	local formspec = "size[8,3]"..
-		"label[3,0;"..minetest.formspec_escape( title or S("Error")).."]"..
-		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape( message or "- nothing -")..";]"..
+		"label[3,0;"..minetest.formspec_escape( title or S("Error") ).."]"..
+		"textlist[0,0.5;8,1.5;;"..minetest.formspec_escape( message or "- nothing -" )..";]"..
 		"button_exit[3.5,2.5;1.0,0.5;back;"..S("Back").."]"..
 		"button_exit[6.8,2.5;1.0,0.5;station_exit;"..S("Exit").."]"..
 		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
-	minetest.show_formspec(player_name, "travelnet:show", formspec)
+	minetest.show_formspec( player_name, "travelnet:show", formspec )
 end
 
 -- show the player the formspec he would see when right-clicking the node;
@@ -21,10 +21,10 @@ travelnet.show_current_formspec = function( pos, meta, player_name )
 		return
 	end
 	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string("formspec")..
+	local formspec = meta:get_string( "formspec" )..
 		"field[20,20;0.1,0.1;pos2str;Pos;".. minetest.pos_to_string( pos ).."]"
 	-- show the formspec manually
-	minetest.show_formspec(player_name, "travelnet:show", formspec)
+	minetest.show_formspec( player_name, "travelnet:show", formspec )
 end
 
 -- a player clicked on something in the formspec hse was manually shown
@@ -39,9 +39,9 @@ travelnet.form_input_handler = function( player, formname, fields)
 		-- back button leads back to the main menu
 		if fields.back and fields.back ~= "" then
 			return travelnet.show_current_formspec( pos,
-					minetest.get_meta( pos ), player:get_player_name())
+					minetest.get_meta( pos ), player:get_player_name() )
 		end
-		return travelnet.on_receive_fields(pos, formname, fields, player)
+		return travelnet.on_receive_fields( pos, formname, fields, player )
 	end
 end
 
@@ -56,27 +56,26 @@ travelnet.reset_formspec = function( meta )
 	if not meta then
 		return
 	end
-	meta:set_string("infotext",       S("Travelnet-box (unconfigured)"))
-	meta:set_string("station_name",   "")
-	meta:set_string("station_network","")
-	meta:set_string("owner",          "")
+	meta:set_string( "infotext",       S("Travelnet-box (unconfigured)") )
+	meta:set_string( "station_name",   "" )
+	meta:set_string( "station_network","" )
+	meta:set_string( "owner",          "" )
 	-- some players seem to be confused with entering network names at first; provide them
 	-- with a default name
 	local station_network = "net1"
 
 	-- request initinal data
-	meta:set_string("formspec",
+	meta:set_string( "formspec",
 		"size[10,6.0]"..
 		"label[2.0,0.0;--> "..S("Configure this travelnet station").." <--]"..
 		"button_exit[8.0,0.0;2.2,0.7;station_dig;"..S("Remove station").."]"..
 		"field[0.3,1.2;9,0.9;station_name;"..S("Name of this station")..":;]"..
 		"label[0.3,1.5;"..S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"...").."]"..
 
-		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..
-		minetest.formspec_escape(station_network or "").."]"..
-		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring(station_network)) .. ".]"..
+		"field[0.3,2.8;9,0.9;station_network;"..S("Assign to Network:")..";"..minetest.formspec_escape( station_network or "" ).."]"..
+		"label[0.3,3.1;"..S("You can have more than one network. If unsure, use \"@1\"", tostring( station_network )) .. ".]"..
 		"field[0.3,4.4;9,0.9;owner;"..S("Owned by:")..";]"..
 		"label[0.3,4.7;"..S("Unless you know what you are doing, leave this empty.").."]"..
 		"button_exit[3.8,5.3;1.7,0.7;station_set;"..S("Save").."]"..
-		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]")
+		"button_exit[6.3,5.3;1.7,0.7;station_exit;"..S("Exit").."]" )
 end

--- a/functions.lua
+++ b/functions.lua
@@ -162,11 +162,13 @@ travelnet.remove_box = function(_, _, oldmetadata, digger)
 	travelnet.targets[owner_name][station_network][station_name] = nil
 
 	-- inform the owner
-	minetest.chat_send_player(owner_name, S("Station '@1'" .. " " ..
-			"has been REMOVED from the network '@2'.", station_name, station_network))
-	if digger ~= nil and owner_name ~= digger:get_player_name() then
-		minetest.chat_send_player(digger:get_player_name(), S("Station '@1'" .. " " ..
+	minetest.chat_send_player(owner_name,
+			S("Station '@1'" .. " " ..
 				"has been REMOVED from the network '@2'.", station_name, station_network))
+	if digger ~= nil and owner_name ~= digger:get_player_name() then
+		minetest.chat_send_player(digger:get_player_name(),
+				S("Station '@1'" .. " " ..
+					"has been REMOVED from the network '@2'.", station_name, station_network))
 	end
 
 	-- save the updated network data in a savefile over server restart

--- a/functions.lua
+++ b/functions.lua
@@ -44,22 +44,30 @@ travelnet.open_close_door = function(pos, player, mode)
 
 		-- at least for homedecor, same facedir would mean "door closed"
 		-- do not close the elevator door if it is already closed
-		if mode == 1 and (string.sub(door_node.name, -7) == '_closed'
-		-- handle doors that change their facedir
-		or (door_node.param2 == ((this_node.param2 + 2) % 4)
-		and door_node.name ~= 'travelnet:elevator_door_glass_open'
-		and door_node.name ~= 'travelnet:elevator_door_tin_open'
-		and door_node.name ~= 'travelnet:elevator_door_steel_open')) then
+		if mode == 1 and (
+			string.sub(door_node.name, -7) == '_closed'
+			-- handle doors that change their facedir
+			or (
+				door_node.param2 == (this_node.param2 + 2) % 4
+				and door_node.name ~= 'travelnet:elevator_door_glass_open'
+				and door_node.name ~= 'travelnet:elevator_door_tin_open'
+				and door_node.name ~= 'travelnet:elevator_door_steel_open'
+			)
+		) then
 			return
 		end
 
 		-- do not open the doors if they are already open (works only on elevator-doors; not on doors in general)
-		if mode == 2 and (string.sub(door_node.name, -5) == '_open'
-		-- handle doors that change their facedir
-		or (door_node.param2 ~= ((this_node.param2 + 2) % 4)
-		and door_node.name ~= 'travelnet:elevator_door_glass_closed'
-		and door_node.name ~= 'travelnet:elevator_door_tin_closed'
-		and door_node.name ~= 'travelnet:elevator_door_steel_closed')) then
+		if mode == 2 and (
+			string.sub(door_node.name, -5) == '_open'
+			-- handle doors that change their facedir
+			or (
+				door_node.param2 ~= ((this_node.param2 + 2) % 4)
+				and door_node.name ~= 'travelnet:elevator_door_glass_closed'
+				and door_node.name ~= 'travelnet:elevator_door_tin_closed'
+				and door_node.name ~= 'travelnet:elevator_door_steel_closed'
+			)
+		) then
 			return
 		end
 
@@ -83,7 +91,7 @@ travelnet.rotate_player = function(target_pos, player, tries)
 	local node2 = minetest.get_node_or_nil(target_pos)
 	if node2 == nil then
 		if tries < 30 then
-			minetest.after(0, travelnet.rotate_player, target_pos, player, tries + 1)
+			minetest.after(0, travelnet.rotate_player, target_pos, player, tries+1)
 		end
 		return
 	end
@@ -130,8 +138,8 @@ end
 
 travelnet.remove_box = function(_, _, oldmetadata, digger)
 	if not oldmetadata or oldmetadata == "nil" or not oldmetadata.fields then
-		minetest.chat_send_player(digger:get_player_name(), S("Error")..": "..
-			S("Could not find information about the station that is to be removed."))
+		minetest.chat_send_player(digger:get_player_name(), S("Error") .. ": " ..
+				S("Could not find information about the station that is to be removed."))
 		return
 	end
 
@@ -140,25 +148,25 @@ travelnet.remove_box = function(_, _, oldmetadata, digger)
 	local station_network = oldmetadata.fields["station_network"]
 
 	-- station is not known? then just remove it
-	if not owner_name
-	or not station_name
-	or not station_network
-	or not travelnet.targets[owner_name]
-	or not travelnet.targets[owner_name][station_network]
+	if	   not owner_name
+		or not station_name
+		or not station_network
+		or not travelnet.targets[owner_name]
+		or not travelnet.targets[owner_name][station_network]
 	then
-		minetest.chat_send_player(digger:get_player_name(), S("Error")..": "..
-		S("Could not find the station that is to be removed."))
+		minetest.chat_send_player(digger:get_player_name(), S("Error") .. ": " ..
+				S("Could not find the station that is to be removed."))
 		return
 	end
 
 	travelnet.targets[owner_name][station_network][station_name] = nil
 
 	-- inform the owner
-	minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
-		"has been REMOVED from the network '@2'.", station_name, station_network))
-	if digger ~= nil and owner_name ~= digger:get_player_name() then
-		minetest.chat_send_player(digger:get_player_name(), S("Station '@1'" .." "..
+	minetest.chat_send_player(owner_name, S("Station '@1'" .. " " ..
 			"has been REMOVED from the network '@2'.", station_name, station_network))
+	if digger ~= nil and owner_name ~= digger:get_player_name() then
+		minetest.chat_send_player(digger:get_player_name(), S("Station '@1'" .. " " ..
+				"has been REMOVED from the network '@2'.", station_name, station_network))
 	end
 
 	-- save the updated network data in a savefile over server restart

--- a/functions.lua
+++ b/functions.lua
@@ -4,17 +4,17 @@ local S = minetest.get_translator("travelnet")
 -- however, that would be very annoying when actually trying to dig the thing.
 -- Thus, check if the player is wielding a tool that can dig nodes of the
 -- group cracky
-travelnet.check_if_trying_to_dig = function( puncher )
+travelnet.check_if_trying_to_dig = function(puncher)
 	-- if in doubt: show formspec
 	if not puncher or not puncher:get_wielded_item() then
 		return false
 	end
 	-- show menu when in creative mode
-	if creative and creative.is_enabled_for( puncher:get_player_name() ) then
+	if creative and creative.is_enabled_for(puncher:get_player_name()) then
 		return false
 	end
 	local tool_capabilities = puncher:get_wielded_item():get_tool_capabilities()
-	if not tool_capabilities or not tool_capabilities[ "groupcaps" ] or not tool_capabilities[ "groupcaps" ][ "cracky" ] then
+	if not tool_capabilities or not tool_capabilities["groupcaps"] or not tool_capabilities["groupcaps"]["cracky"] then
 		return false
 	end
 	-- tools which can dig cracky items can start digging immediately
@@ -23,28 +23,28 @@ end
 
 
 -- allow doors to open
-travelnet.open_close_door = function( pos, player, mode )
-	local this_node = minetest.get_node_or_nil( pos )
+travelnet.open_close_door = function(pos, player, mode)
+	local this_node = minetest.get_node_or_nil(pos)
 	-- give up if the area is *still* not loaded
 	if not this_node then
 		return
 	end
-	local pos2 = { x = pos.x, y = pos.y, z = pos.z }
+	local pos2 = { x=pos.x, y=pos.y, z=pos.z }
 
-	if     this_node.param2 == 0 then pos2 = { x = pos.x,     y = pos.y, z = (pos.z-1) }
-	elseif this_node.param2 == 1 then pos2 = { x = (pos.x-1), y = pos.y, z = pos.z     }
-	elseif this_node.param2 == 2 then pos2 = { x = pos.x,     y = pos.y, z = (pos.z+1) }
-	elseif this_node.param2 == 3 then pos2 = { x = (pos.x+1), y = pos.y, z = pos.z     }
+	if     this_node.param2 == 0 then pos2 = { x=pos.x,     y=pos.y, z=(pos.z-1) }
+	elseif this_node.param2 == 1 then pos2 = { x=(pos.x-1), y=pos.y, z=pos.z     }
+	elseif this_node.param2 == 2 then pos2 = { x=pos.x,     y=pos.y, z=(pos.z+1) }
+	elseif this_node.param2 == 3 then pos2 = { x=(pos.x+1), y=pos.y, z=pos.z     }
 	end
 
-	local door_node = minetest.get_node( pos2 )
+	local door_node = minetest.get_node(pos2)
 	if door_node and door_node.name ~= 'ignore' and door_node.name ~= 'air' and
-		minetest.registered_nodes[ door_node.name ] ~= nil and
-		minetest.registered_nodes[ door_node.name ].on_rightclick ~= nil then
+		minetest.registered_nodes[door_node.name] ~= nil and
+		minetest.registered_nodes[door_node.name].on_rightclick ~= nil then
 
 		-- at least for homedecor, same facedir would mean "door closed"
 		-- do not close the elevator door if it is already closed
-		if mode == 1 and ( string.sub( door_node.name, -7 ) == '_closed'
+		if mode == 1 and (string.sub(door_node.name, -7) == '_closed'
 		-- handle doors that change their facedir
 		or (door_node.param2 == ((this_node.param2 + 2) % 4)
 		and door_node.name ~= 'travelnet:elevator_door_glass_open'
@@ -54,7 +54,7 @@ travelnet.open_close_door = function( pos, player, mode )
 		end
 
 		-- do not open the doors if they are already open (works only on elevator-doors; not on doors in general)
-		if mode == 2 and ( string.sub( door_node.name, -5 ) == '_open'
+		if mode == 2 and (string.sub(door_node.name, -5) == '_open'
 		-- handle doors that change their facedir
 		or (door_node.param2 ~= ((this_node.param2 + 2) % 4)
 		and door_node.name ~= 'travelnet:elevator_door_glass_closed'
@@ -66,24 +66,24 @@ travelnet.open_close_door = function( pos, player, mode )
 		if mode == 2 then
 			local playername = player:get_player_name()
 			minetest.after(1, function()
-				local pplayer = minetest.get_player_by_name( playername )
+				local pplayer = minetest.get_player_by_name(playername)
 				if pplayer then
-					minetest.registered_nodes[ door_node.name ].on_rightclick( pos2, door_node, pplayer )
+					minetest.registered_nodes[door_node.name].on_rightclick(pos2, door_node, pplayer)
 				end
 			end)
 		else
-			minetest.registered_nodes[ door_node.name ].on_rightclick( pos2, door_node, player )
+			minetest.registered_nodes[door_node.name].on_rightclick(pos2, door_node, player)
 		end
 	end
 end
 
 
-travelnet.rotate_player = function( target_pos, player, tries )
+travelnet.rotate_player = function(target_pos, player, tries)
 	-- try later when the box is loaded
-	local node2 = minetest.get_node_or_nil( target_pos )
+	local node2 = minetest.get_node_or_nil(target_pos)
 	if node2 == nil then
 		if tries < 30 then
-			minetest.after( 0, travelnet.rotate_player, target_pos, player, tries + 1 )
+			minetest.after(0, travelnet.rotate_player, target_pos, player, tries + 1)
 		end
 		return
 	end
@@ -91,9 +91,17 @@ travelnet.rotate_player = function( target_pos, player, tries )
 	-- play sound at the target position as well
 	if travelnet.travelnet_sound_enabled then
 		if node2.name == 'travelnet:elevator' then
-			minetest.sound_play( "travelnet_bell",   { pos = target_pos, gain = 0.75, max_hear_distance = 10 } )
+			minetest.sound_play("travelnet_bell",   {
+				pos = target_pos,
+				gain = 0.75,
+				max_hear_distance = 10
+			})
 		else
-			minetest.sound_play( "travelnet_travel", { pos = target_pos, gain = 0.75, max_hear_distance = 10 } )
+			minetest.sound_play("travelnet_travel", {
+				pos = target_pos,
+				gain = 0.75,
+				max_hear_distance = 10
+			})
 		end
 	end
 
@@ -112,45 +120,45 @@ travelnet.rotate_player = function( target_pos, player, tries )
 			yaw = 270
 		end
 
-		player:set_look_horizontal( math.rad( yaw ) )
-		player:set_look_vertical( math.rad( 0 ) )
+		player:set_look_horizontal(math.rad(yaw))
+		player:set_look_vertical(math.rad(0))
 	end
 
-	travelnet.open_close_door( target_pos, player, 2 )
+	travelnet.open_close_door(target_pos, player, 2)
 end
 
 
-travelnet.remove_box = function( _, _, oldmetadata, digger )
+travelnet.remove_box = function(_, _, oldmetadata, digger)
 	if not oldmetadata or oldmetadata == "nil" or not oldmetadata.fields then
-		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
+		minetest.chat_send_player(digger:get_player_name(), S("Error")..": "..
 			S("Could not find information about the station that is to be removed."))
 		return
 	end
 
-	local owner_name      = oldmetadata.fields[ "owner" ]
-	local station_name    = oldmetadata.fields[ "station_name" ]
-	local station_network = oldmetadata.fields[ "station_network" ]
+	local owner_name      = oldmetadata.fields["owner"]
+	local station_name    = oldmetadata.fields["station_name"]
+	local station_network = oldmetadata.fields["station_network"]
 
 	-- station is not known? then just remove it
 	if not owner_name
 	or not station_name
 	or not station_network
-	or not travelnet.targets[ owner_name ]
-	or not travelnet.targets[ owner_name ][ station_network ]
+	or not travelnet.targets[owner_name]
+	or not travelnet.targets[owner_name][station_network]
 	then
-		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
+		minetest.chat_send_player(digger:get_player_name(), S("Error")..": "..
 		S("Could not find the station that is to be removed."))
 		return
 	end
 
-	travelnet.targets[ owner_name ][ station_network ][ station_name ] = nil
+	travelnet.targets[owner_name][station_network][station_name] = nil
 
 	-- inform the owner
-	minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
-		"has been REMOVED from the network '@2'.", station_name, station_network) )
+	minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
+		"has been REMOVED from the network '@2'.", station_name, station_network))
 	if digger ~= nil and owner_name ~= digger:get_player_name() then
-		minetest.chat_send_player( digger:get_player_name(), S("Station '@1'" .." "..
-			"has been REMOVED from the network '@2'.", station_name, station_network) )
+		minetest.chat_send_player(digger:get_player_name(), S("Station '@1'" .." "..
+			"has been REMOVED from the network '@2'.", station_name, station_network))
 	end
 
 	-- save the updated network data in a savefile over server restart

--- a/functions.lua
+++ b/functions.lua
@@ -38,20 +38,20 @@ travelnet.open_close_door = function(pos, player, mode)
 	end
 
 	local door_node = minetest.get_node(pos2)
-	if door_node and door_node.name ~= 'ignore' and door_node.name ~= 'air' and
+	if door_node and door_node.name ~= "ignore" and door_node.name ~= "air" and
 		minetest.registered_nodes[door_node.name] ~= nil and
 		minetest.registered_nodes[door_node.name].on_rightclick ~= nil then
 
 		-- at least for homedecor, same facedir would mean "door closed"
 		-- do not close the elevator door if it is already closed
 		if mode == 1 and (
-			string.sub(door_node.name, -7) == '_closed'
+			string.sub(door_node.name, -7) == "_closed"
 			-- handle doors that change their facedir
 			or (
 				door_node.param2 == (this_node.param2 + 2) % 4
-				and door_node.name ~= 'travelnet:elevator_door_glass_open'
-				and door_node.name ~= 'travelnet:elevator_door_tin_open'
-				and door_node.name ~= 'travelnet:elevator_door_steel_open'
+				and door_node.name ~= "travelnet:elevator_door_glass_open"
+				and door_node.name ~= "travelnet:elevator_door_tin_open"
+				and door_node.name ~= "travelnet:elevator_door_steel_open"
 			)
 		) then
 			return
@@ -59,13 +59,13 @@ travelnet.open_close_door = function(pos, player, mode)
 
 		-- do not open the doors if they are already open (works only on elevator-doors; not on doors in general)
 		if mode == 2 and (
-			string.sub(door_node.name, -5) == '_open'
+			string.sub(door_node.name, -5) == "_open"
 			-- handle doors that change their facedir
 			or (
 				door_node.param2 ~= ((this_node.param2 + 2) % 4)
-				and door_node.name ~= 'travelnet:elevator_door_glass_closed'
-				and door_node.name ~= 'travelnet:elevator_door_tin_closed'
-				and door_node.name ~= 'travelnet:elevator_door_steel_closed'
+				and door_node.name ~= "travelnet:elevator_door_glass_closed"
+				and door_node.name ~= "travelnet:elevator_door_tin_closed"
+				and door_node.name ~= "travelnet:elevator_door_steel_closed"
 			)
 		) then
 			return
@@ -98,7 +98,7 @@ travelnet.rotate_player = function(target_pos, player, tries)
 
 	-- play sound at the target position as well
 	if travelnet.travelnet_sound_enabled then
-		if node2.name == 'travelnet:elevator' then
+		if node2.name == "travelnet:elevator" then
 			minetest.sound_play("travelnet_bell",   {
 				pos = target_pos,
 				gain = 0.75,

--- a/functions.lua
+++ b/functions.lua
@@ -7,60 +7,60 @@ local S = minetest.get_translator("travelnet")
 travelnet.check_if_trying_to_dig = function(puncher)
 	-- if in doubt: show formspec
 	if not puncher or not puncher:get_wielded_item() then
-		return false;
+		return false
 	end
 	-- show menu when in creative mode
 	if creative and creative.is_enabled_for(puncher:get_player_name()) then
-		return false;
+		return false
 	end
-	local tool_capabilities = puncher:get_wielded_item():get_tool_capabilities();
+	local tool_capabilities = puncher:get_wielded_item():get_tool_capabilities()
 	if not tool_capabilities or not tool_capabilities["groupcaps"] or not tool_capabilities["groupcaps"]["cracky"] then
-		return false;
+		return false
 	end
 	-- tools which can dig cracky items can start digging immediately
-	return true;
+	return true
 end
 
 
 -- allow doors to open
 travelnet.open_close_door = function( pos, player, mode )
-	local this_node = minetest.get_node_or_nil( pos );
+	local this_node = minetest.get_node_or_nil( pos )
 	-- give up if the area is *still* not loaded
 	if not this_node then
 		return
 	end
-	local pos2 = {x=pos.x,y=pos.y,z=pos.z};
+	local pos2 = {x=pos.x,y=pos.y,z=pos.z}
 
-	if(     this_node.param2 == 0 ) then pos2 = {x=pos.x,y=pos.y,z=(pos.z-1)};
-	elseif( this_node.param2 == 1 ) then pos2 = {x=(pos.x-1),y=pos.y,z=pos.z};
-	elseif( this_node.param2 == 2 ) then pos2 = {x=pos.x,y=pos.y,z=(pos.z+1)};
-	elseif( this_node.param2 == 3 ) then pos2 = {x=(pos.x+1),y=pos.y,z=pos.z};
+	if     this_node.param2 == 0 then pos2 = {x=pos.x,y=pos.y,z=(pos.z-1)}
+	elseif this_node.param2 == 1 then pos2 = {x=(pos.x-1),y=pos.y,z=pos.z}
+	elseif this_node.param2 == 2 then pos2 = {x=pos.x,y=pos.y,z=(pos.z+1)}
+	elseif this_node.param2 == 3 then pos2 = {x=(pos.x+1),y=pos.y,z=pos.z}
 	end
 
-	local door_node = minetest.get_node(pos2);
+	local door_node = minetest.get_node(pos2)
 	if door_node and door_node.name ~= 'ignore' and door_node.name ~= 'air' and
 		minetest.registered_nodes[ door_node.name ] ~= nil and
 		minetest.registered_nodes[ door_node.name ].on_rightclick ~= nil then
 
 		-- at least for homedecor, same facedir would mean "door closed"
 		-- do not close the elevator door if it is already closed
-		if (mode==1 and ( string.sub( door_node.name, -7 ) == '_closed'
+		if mode==1 and ( string.sub( door_node.name, -7 ) == '_closed'
 		-- handle doors that change their facedir
 			or ( door_node.param2 == ((this_node.param2 + 2)%4)
 			and door_node.name ~= 'travelnet:elevator_door_glass_open'
 			and door_node.name ~= 'travelnet:elevator_door_tin_open'
-			and door_node.name ~= 'travelnet:elevator_door_steel_open'))) then
-				return;
+			and door_node.name ~= 'travelnet:elevator_door_steel_open')) then
+			return
 		end
 
 		-- do not open the doors if they are already open (works only on elevator-doors; not on doors in general)
-		if( mode==2 and ( string.sub( door_node.name, -5 ) == '_open'
+		if mode==2 and ( string.sub( door_node.name, -5 ) == '_open'
 			-- handle doors that change their facedir
 			or ( door_node.param2 ~= ((this_node.param2 + 2)%4)
 			and door_node.name ~= 'travelnet:elevator_door_glass_closed'
 			and door_node.name ~= 'travelnet:elevator_door_tin_closed'
-			and door_node.name ~= 'travelnet:elevator_door_steel_closed'))) then
-				return;
+			and door_node.name ~= 'travelnet:elevator_door_steel_closed')) then
+			return
 		end
 
 		if mode == 2 then
@@ -68,11 +68,11 @@ travelnet.open_close_door = function( pos, player, mode )
 			minetest.after(1, function()
 				local pplayer = minetest.get_player_by_name(playername)
 				if pplayer then
-					minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, pplayer);
+					minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, pplayer)
 				end
-			end);
+			end)
 		else
-			minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, player);
+			minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, player)
 		end
 	end
 end
@@ -80,7 +80,7 @@ end
 
 travelnet.rotate_player = function( target_pos, player, tries )
 	-- try later when the box is loaded
-	local node2 = minetest.get_node_or_nil( target_pos );
+	local node2 = minetest.get_node_or_nil( target_pos )
 	if node2 == nil then
 		if tries < 30 then
 			minetest.after( 0, travelnet.rotate_player, target_pos, player, tries+1 )
@@ -89,77 +89,77 @@ travelnet.rotate_player = function( target_pos, player, tries )
 	end
 
 	-- play sound at the target position as well
-	if( travelnet.travelnet_sound_enabled ) then
-		if ( node2.name == 'travelnet:elevator' ) then
-			minetest.sound_play("travelnet_bell", {pos = target_pos, gain = 0.75, max_hear_distance = 10,});
+	if travelnet.travelnet_sound_enabled then
+		if node2.name == 'travelnet:elevator' then
+			minetest.sound_play("travelnet_bell", {pos = target_pos, gain = 0.75, max_hear_distance = 10,})
 		else
-			minetest.sound_play("travelnet_travel", {pos = target_pos, gain = 0.75, max_hear_distance = 10,});
+			minetest.sound_play("travelnet_travel", {pos = target_pos, gain = 0.75, max_hear_distance = 10,})
 		end
 	end
 
 	-- do this only on servers where the function exists
 	if player.set_look_horizontal then
 	-- rotate the player so that he/she can walk straight out of the box
-		local yaw    = 0;
-		local param2 = node2.param2;
+		local yaw    = 0
+		local param2 = node2.param2
 		if( param2==0 ) then
-			yaw = 180;
+			yaw = 180
 		elseif param2==1 then
-			yaw = 90;
+			yaw = 90
 		elseif param2==2 then
-			yaw = 0;
+			yaw = 0
 		elseif param2==3 then
-			yaw = 270;
+			yaw = 270
 		end
 
-		player:set_look_horizontal( math.rad( yaw ));
-		player:set_look_vertical( math.rad( 0 ));
+		player:set_look_horizontal( math.rad( yaw ) )
+		player:set_look_vertical( math.rad( 0 ) )
 	end
 
-	travelnet.open_close_door( target_pos, player, 2 );
+	travelnet.open_close_door( target_pos, player, 2 )
 end
 
 
 travelnet.remove_box = function(_, _, oldmetadata, digger )
-	if not oldmetadata or oldmetadata=="nil" or not oldmetadata.fields then
-	minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
-		S("Could not find information about the station that is to be removed."));
-		return;
+	if not oldmetadata or oldmetadata == "nil" or not oldmetadata.fields then
+		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
+			S("Could not find information about the station that is to be removed."))
+		return
 	end
 
-	local owner_name      = oldmetadata.fields[ "owner" ];
-	local station_name    = oldmetadata.fields[ "station_name" ];
-	local station_network = oldmetadata.fields[ "station_network" ];
+	local owner_name      = oldmetadata.fields[ "owner" ]
+	local station_name    = oldmetadata.fields[ "station_name" ]
+	local station_network = oldmetadata.fields[ "station_network" ]
 
 	-- station is not known? then just remove it
-	if(  not( owner_name )
-		or not( station_name )
-		or not( station_network )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
-
+	if not( owner_name )
+	or not( station_name )
+	or not( station_network )
+	or not( travelnet.targets[ owner_name ] )
+	or not( travelnet.targets[ owner_name ][ station_network ] )
+	then
 		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
-		S("Could not find the station that is to be removed."));
-		return;
+		S("Could not find the station that is to be removed."))
+		return
 	end
 
-	travelnet.targets[ owner_name ][ station_network ][ station_name ] = nil;
+	travelnet.targets[ owner_name ][ station_network ][ station_name ] = nil
 
 	-- inform the owner
 	minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
-		"has been REMOVED from the network '@2'.", station_name, station_network));
+		"has been REMOVED from the network '@2'.", station_name, station_network))
 	if digger ~= nil and owner_name ~= digger:get_player_name() then
 		minetest.chat_send_player( digger:get_player_name(), S("Station '@1'" .." "..
-			"has been REMOVED from the network '@2'.", station_name, station_network));
+			"has been REMOVED from the network '@2'.", station_name, station_network))
 	end
 
 	-- save the updated network data in a savefile over server restart
-	travelnet.save_data();
+	travelnet.save_data()
 end
 
 
 
 travelnet.can_dig = function()
 	-- forbid digging of the travelnet
-	return false;
+	return false
 end

--- a/functions.lua
+++ b/functions.lua
@@ -4,17 +4,17 @@ local S = minetest.get_translator("travelnet")
 -- however, that would be very annoying when actually trying to dig the thing.
 -- Thus, check if the player is wielding a tool that can dig nodes of the
 -- group cracky
-travelnet.check_if_trying_to_dig = function(puncher)
+travelnet.check_if_trying_to_dig = function( puncher )
 	-- if in doubt: show formspec
 	if not puncher or not puncher:get_wielded_item() then
 		return false
 	end
 	-- show menu when in creative mode
-	if creative and creative.is_enabled_for(puncher:get_player_name()) then
+	if creative and creative.is_enabled_for( puncher:get_player_name() ) then
 		return false
 	end
 	local tool_capabilities = puncher:get_wielded_item():get_tool_capabilities()
-	if not tool_capabilities or not tool_capabilities["groupcaps"] or not tool_capabilities["groupcaps"]["cracky"] then
+	if not tool_capabilities or not tool_capabilities[ "groupcaps" ] or not tool_capabilities[ "groupcaps" ][ "cracky" ] then
 		return false
 	end
 	-- tools which can dig cracky items can start digging immediately
@@ -29,50 +29,50 @@ travelnet.open_close_door = function( pos, player, mode )
 	if not this_node then
 		return
 	end
-	local pos2 = {x=pos.x,y=pos.y,z=pos.z}
+	local pos2 = { x = pos.x, y = pos.y, z = pos.z }
 
-	if     this_node.param2 == 0 then pos2 = {x=pos.x,y=pos.y,z=(pos.z-1)}
-	elseif this_node.param2 == 1 then pos2 = {x=(pos.x-1),y=pos.y,z=pos.z}
-	elseif this_node.param2 == 2 then pos2 = {x=pos.x,y=pos.y,z=(pos.z+1)}
-	elseif this_node.param2 == 3 then pos2 = {x=(pos.x+1),y=pos.y,z=pos.z}
+	if     this_node.param2 == 0 then pos2 = { x = pos.x,     y = pos.y, z = (pos.z-1) }
+	elseif this_node.param2 == 1 then pos2 = { x = (pos.x-1), y = pos.y, z = pos.z     }
+	elseif this_node.param2 == 2 then pos2 = { x = pos.x,     y = pos.y, z = (pos.z+1) }
+	elseif this_node.param2 == 3 then pos2 = { x = (pos.x+1), y = pos.y, z = pos.z     }
 	end
 
-	local door_node = minetest.get_node(pos2)
+	local door_node = minetest.get_node( pos2 )
 	if door_node and door_node.name ~= 'ignore' and door_node.name ~= 'air' and
 		minetest.registered_nodes[ door_node.name ] ~= nil and
 		minetest.registered_nodes[ door_node.name ].on_rightclick ~= nil then
 
 		-- at least for homedecor, same facedir would mean "door closed"
 		-- do not close the elevator door if it is already closed
-		if mode==1 and ( string.sub( door_node.name, -7 ) == '_closed'
+		if mode == 1 and ( string.sub( door_node.name, -7 ) == '_closed'
 		-- handle doors that change their facedir
-			or ( door_node.param2 == ((this_node.param2 + 2)%4)
-			and door_node.name ~= 'travelnet:elevator_door_glass_open'
-			and door_node.name ~= 'travelnet:elevator_door_tin_open'
-			and door_node.name ~= 'travelnet:elevator_door_steel_open')) then
+		or (door_node.param2 == ((this_node.param2 + 2) % 4)
+		and door_node.name ~= 'travelnet:elevator_door_glass_open'
+		and door_node.name ~= 'travelnet:elevator_door_tin_open'
+		and door_node.name ~= 'travelnet:elevator_door_steel_open')) then
 			return
 		end
 
 		-- do not open the doors if they are already open (works only on elevator-doors; not on doors in general)
-		if mode==2 and ( string.sub( door_node.name, -5 ) == '_open'
-			-- handle doors that change their facedir
-			or ( door_node.param2 ~= ((this_node.param2 + 2)%4)
-			and door_node.name ~= 'travelnet:elevator_door_glass_closed'
-			and door_node.name ~= 'travelnet:elevator_door_tin_closed'
-			and door_node.name ~= 'travelnet:elevator_door_steel_closed')) then
+		if mode == 2 and ( string.sub( door_node.name, -5 ) == '_open'
+		-- handle doors that change their facedir
+		or (door_node.param2 ~= ((this_node.param2 + 2) % 4)
+		and door_node.name ~= 'travelnet:elevator_door_glass_closed'
+		and door_node.name ~= 'travelnet:elevator_door_tin_closed'
+		and door_node.name ~= 'travelnet:elevator_door_steel_closed')) then
 			return
 		end
 
 		if mode == 2 then
 			local playername = player:get_player_name()
 			minetest.after(1, function()
-				local pplayer = minetest.get_player_by_name(playername)
+				local pplayer = minetest.get_player_by_name( playername )
 				if pplayer then
-					minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, pplayer)
+					minetest.registered_nodes[ door_node.name ].on_rightclick( pos2, door_node, pplayer )
 				end
 			end)
 		else
-			minetest.registered_nodes[ door_node.name ].on_rightclick(pos2, door_node, player)
+			minetest.registered_nodes[ door_node.name ].on_rightclick( pos2, door_node, player )
 		end
 	end
 end
@@ -83,7 +83,7 @@ travelnet.rotate_player = function( target_pos, player, tries )
 	local node2 = minetest.get_node_or_nil( target_pos )
 	if node2 == nil then
 		if tries < 30 then
-			minetest.after( 0, travelnet.rotate_player, target_pos, player, tries+1 )
+			minetest.after( 0, travelnet.rotate_player, target_pos, player, tries + 1 )
 		end
 		return
 	end
@@ -91,9 +91,9 @@ travelnet.rotate_player = function( target_pos, player, tries )
 	-- play sound at the target position as well
 	if travelnet.travelnet_sound_enabled then
 		if node2.name == 'travelnet:elevator' then
-			minetest.sound_play("travelnet_bell", {pos = target_pos, gain = 0.75, max_hear_distance = 10,})
+			minetest.sound_play( "travelnet_bell",   { pos = target_pos, gain = 0.75, max_hear_distance = 10 } )
 		else
-			minetest.sound_play("travelnet_travel", {pos = target_pos, gain = 0.75, max_hear_distance = 10,})
+			minetest.sound_play( "travelnet_travel", { pos = target_pos, gain = 0.75, max_hear_distance = 10 } )
 		end
 	end
 
@@ -102,13 +102,13 @@ travelnet.rotate_player = function( target_pos, player, tries )
 	-- rotate the player so that he/she can walk straight out of the box
 		local yaw    = 0
 		local param2 = node2.param2
-		if( param2==0 ) then
+		if     param2 == 0 then
 			yaw = 180
-		elseif param2==1 then
+		elseif param2 == 1 then
 			yaw = 90
-		elseif param2==2 then
+		elseif param2 == 2 then
 			yaw = 0
-		elseif param2==3 then
+		elseif param2 == 3 then
 			yaw = 270
 		end
 
@@ -120,7 +120,7 @@ travelnet.rotate_player = function( target_pos, player, tries )
 end
 
 
-travelnet.remove_box = function(_, _, oldmetadata, digger )
+travelnet.remove_box = function( _, _, oldmetadata, digger )
 	if not oldmetadata or oldmetadata == "nil" or not oldmetadata.fields then
 		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
 			S("Could not find information about the station that is to be removed."))
@@ -132,11 +132,11 @@ travelnet.remove_box = function(_, _, oldmetadata, digger )
 	local station_network = oldmetadata.fields[ "station_network" ]
 
 	-- station is not known? then just remove it
-	if not( owner_name )
-	or not( station_name )
-	or not( station_network )
-	or not( travelnet.targets[ owner_name ] )
-	or not( travelnet.targets[ owner_name ][ station_network ] )
+	if not owner_name
+	or not station_name
+	or not station_network
+	or not travelnet.targets[ owner_name ]
+	or not travelnet.targets[ owner_name ][ station_network ]
 	then
 		minetest.chat_send_player( digger:get_player_name(), S("Error")..": "..
 		S("Could not find the station that is to be removed."))
@@ -147,10 +147,10 @@ travelnet.remove_box = function(_, _, oldmetadata, digger )
 
 	-- inform the owner
 	minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
-		"has been REMOVED from the network '@2'.", station_name, station_network))
+		"has been REMOVED from the network '@2'.", station_name, station_network) )
 	if digger ~= nil and owner_name ~= digger:get_player_name() then
 		minetest.chat_send_player( digger:get_player_name(), S("Station '@1'" .." "..
-			"has been REMOVED from the network '@2'.", station_name, station_network))
+			"has been REMOVED from the network '@2'.", station_name, station_network) )
 	end
 
 	-- save the updated network data in a savefile over server restart

--- a/init.lua
+++ b/init.lua
@@ -20,13 +20,13 @@
 --]]
 
 -- integration test
-if minetest.settings:get_bool( "travelnet.enable_travelnet_integration_test" ) then
-	dofile( minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua" )
+if minetest.settings:get_bool("travelnet.enable_travelnet_integration_test") then
+	dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua")
 end
 
 -- Required to save the travelnet data properly in all cases
 if not minetest.safe_file_write then
-	error( "[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)" )
+	error("[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)")
 end
 
 travelnet = {}
@@ -35,38 +35,38 @@ travelnet.targets = {}
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
 -- privs
-dofile( travelnet.path.."/privs.lua" )
+dofile(travelnet.path.."/privs.lua")
 
 -- read the configuration
-dofile( travelnet.path.."/config.lua" )
+dofile(travelnet.path.."/config.lua")
 
 -- saving / reading
-dofile( travelnet.path.."/persistence.lua" )
+dofile(travelnet.path.."/persistence.lua")
 
 -- common functions
-dofile( travelnet.path.."/functions.lua" )
+dofile(travelnet.path.."/functions.lua")
 
 -- formspec stuff
-dofile( travelnet.path.."/formspecs.lua" )
+dofile(travelnet.path.."/formspecs.lua")
 
 -- travelnet / elevator update
-dofile( travelnet.path.."/update_formspec.lua" )
+dofile(travelnet.path.."/update_formspec.lua")
 
 -- add button
-dofile( travelnet.path.."/add_target.lua" )
+dofile(travelnet.path.."/add_target.lua")
 
 -- receive fields handler
-dofile( travelnet.path.."/on_receive_fields.lua" )
+dofile(travelnet.path.."/on_receive_fields.lua")
 
 -- invisible node to place inside top of travelnet box and elevator
-minetest.register_node( "travelnet:hidden_top", {
+minetest.register_node("travelnet:hidden_top", {
 	drawtype = "nodebox",
 	paramtype = "light",
 	sunlight_propagates = true,
 	pointable = false,
 	diggable = false,
 	drop = "",
-	groups = { not_in_creative_inventory = 1 },
+	groups = { not_in_creative_inventory=1 },
 	tiles = { "travelnet_blank.png" },
 	use_texture_alpha = "clip",
 	node_box = {
@@ -77,56 +77,56 @@ minetest.register_node( "travelnet:hidden_top", {
 		type = "fixed",
 		fixed = { -0.5, 0.45, -0.5, 0.5, 0.5, 0.5 },
 	},
-} )
+})
 
 
 if travelnet.travelnet_effect_enabled then
-	minetest.register_entity( "travelnet:effect", {
+	minetest.register_entity("travelnet:effect", {
 		hp_max = 1,
 		physical = false,
 		weight = 5,
 		collisionbox = { -0.4, -0.5, -0.4, 0.4, 1.5, 0.4 },
 		visual = "upright_sprite",
-		visual_size = { x = 1, y = 2 },
+		visual_size = { x=1, y=2 },
 		textures = { "travelnet_flash.png" }, -- number of required textures depends on visual
-		spritediv = { x = 1, y = 1 },
-		initial_sprite_basepos = { x = 0, y = 0 },
+		spritediv = { x=1, y=1 },
+		initial_sprite_basepos = { x=0, y=0 },
 		is_visible = true,
 		makes_footstep_sound = false,
 		automatic_rotate = true,
 
 		anz_rotations = 0,
 
-		on_step = function( self )
+		on_step = function(self)
 			-- this is supposed to be more flickering than smooth animation
-			self.object:set_yaw( self.object:get_yaw() + 1 )
-			self.anz_rotations = self.anz_rotations + 1
+			self.object:set_yaw(self.object:get_yaw()+1)
+			self.anz_rotations = self.anz_rotations+1
 			-- eventually self-destruct
 			if self.anz_rotations > 15 then
 				self.object:remove()
 			end
 		end
-	} )
+	})
 end
 
 
 if travelnet.travelnet_enabled then
 	-- register-functions for travelnet nodes
-	dofile( travelnet.path.."/register_travelnet.lua" )
+	dofile(travelnet.path.."/register_travelnet.lua")
 	-- default travelnet registrations
-	dofile( travelnet.path.."/travelnet.lua" )
+	dofile(travelnet.path.."/travelnet.lua")
 end
 if travelnet.elevator_enabled then
-	dofile( travelnet.path.."/elevator.lua" )  -- allows up/down transfers only
+	dofile(travelnet.path.."/elevator.lua")  -- allows up/down transfers only
 end
 if travelnet.doors_enabled then
 	-- doors that open and close automaticly when the travelnet or elevator is used
-	dofile( travelnet.path.."/doors.lua" )
+	dofile(travelnet.path.."/doors.lua")
 end
 
 if travelnet.enable_abm then
 	-- restore travelnet data when players pass by broken networks
-	dofile( travelnet.path.."/restore_network_via_abm.lua" )
+	dofile(travelnet.path.."/restore_network_via_abm.lua")
 end
 
 -- upon server start, read the savefile

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,3 @@
-
-
 --[[
 	Teleporter networks that allow players to choose a destination out of a list
 	Copyright (C) 2013 Sokomine
@@ -35,28 +33,28 @@ travelnet.targets = {}
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
 -- privs
-dofile(travelnet.path.."/privs.lua")
+dofile(travelnet.path .. "/privs.lua")
 
 -- read the configuration
-dofile(travelnet.path.."/config.lua")
+dofile(travelnet.path .. "/config.lua")
 
 -- saving / reading
-dofile(travelnet.path.."/persistence.lua")
+dofile(travelnet.path .. "/persistence.lua")
 
 -- common functions
-dofile(travelnet.path.."/functions.lua")
+dofile(travelnet.path .. "/functions.lua")
 
 -- formspec stuff
-dofile(travelnet.path.."/formspecs.lua")
+dofile(travelnet.path .. "/formspecs.lua")
 
 -- travelnet / elevator update
-dofile(travelnet.path.."/update_formspec.lua")
+dofile(travelnet.path .. "/update_formspec.lua")
 
 -- add button
-dofile(travelnet.path.."/add_target.lua")
+dofile(travelnet.path .. "/add_target.lua")
 
 -- receive fields handler
-dofile(travelnet.path.."/on_receive_fields.lua")
+dofile(travelnet.path .. "/on_receive_fields.lua")
 
 -- invisible node to place inside top of travelnet box and elevator
 minetest.register_node("travelnet:hidden_top", {
@@ -112,21 +110,21 @@ end
 
 if travelnet.travelnet_enabled then
 	-- register-functions for travelnet nodes
-	dofile(travelnet.path.."/register_travelnet.lua")
+	dofile(travelnet.path .. "/register_travelnet.lua")
 	-- default travelnet registrations
-	dofile(travelnet.path.."/travelnet.lua")
+	dofile(travelnet.path .. "/travelnet.lua")
 end
 if travelnet.elevator_enabled then
-	dofile(travelnet.path.."/elevator.lua")  -- allows up/down transfers only
+	dofile(travelnet.path .. "/elevator.lua")  -- allows up/down transfers only
 end
 if travelnet.doors_enabled then
 	-- doors that open and close automaticly when the travelnet or elevator is used
-	dofile(travelnet.path.."/doors.lua")
+	dofile(travelnet.path .. "/doors.lua")
 end
 
 if travelnet.enable_abm then
 	-- restore travelnet data when players pass by broken networks
-	dofile(travelnet.path.."/restore_network_via_abm.lua")
+	dofile(travelnet.path .. "/restore_network_via_abm.lua")
 end
 
 -- upon server start, read the savefile

--- a/init.lua
+++ b/init.lua
@@ -20,13 +20,13 @@
 --]]
 
 -- integration test
-if minetest.settings:get_bool("travelnet.enable_travelnet_integration_test") then
-	dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua")
+if minetest.settings:get_bool( "travelnet.enable_travelnet_integration_test" ) then
+	dofile( minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua" )
 end
 
 -- Required to save the travelnet data properly in all cases
 if not minetest.safe_file_write then
-	error("[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)")
+	error( "[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)" )
 end
 
 travelnet = {}
@@ -35,98 +35,98 @@ travelnet.targets = {}
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
 -- privs
-dofile(travelnet.path.."/privs.lua")
+dofile( travelnet.path.."/privs.lua" )
 
 -- read the configuration
-dofile(travelnet.path.."/config.lua")
+dofile( travelnet.path.."/config.lua" )
 
 -- saving / reading
-dofile(travelnet.path.."/persistence.lua")
+dofile( travelnet.path.."/persistence.lua" )
 
 -- common functions
-dofile(travelnet.path.."/functions.lua")
+dofile( travelnet.path.."/functions.lua" )
 
 -- formspec stuff
-dofile(travelnet.path.."/formspecs.lua")
+dofile( travelnet.path.."/formspecs.lua" )
 
 -- travelnet / elevator update
-dofile(travelnet.path.."/update_formspec.lua")
+dofile( travelnet.path.."/update_formspec.lua" )
 
 -- add button
-dofile(travelnet.path.."/add_target.lua")
+dofile( travelnet.path.."/add_target.lua" )
 
 -- receive fields handler
-dofile(travelnet.path.."/on_receive_fields.lua")
+dofile( travelnet.path.."/on_receive_fields.lua" )
 
 -- invisible node to place inside top of travelnet box and elevator
-minetest.register_node("travelnet:hidden_top", {
+minetest.register_node( "travelnet:hidden_top", {
 	drawtype = "nodebox",
 	paramtype = "light",
 	sunlight_propagates = true,
 	pointable = false,
 	diggable = false,
 	drop = "",
-	groups = {not_in_creative_inventory = 1},
-	tiles = {"travelnet_blank.png"},
+	groups = { not_in_creative_inventory = 1 },
+	tiles = { "travelnet_blank.png" },
 	use_texture_alpha = "clip",
 	node_box = {
 		type = "fixed",
-		fixed = { -0.5, 0.45,-0.5,0.5, 0.5, 0.5},
+		fixed = { -0.5, 0.45, -0.5, 0.5, 0.5, 0.5 },
 	},
 	collision_box = {
 		type = "fixed",
-		fixed = { -0.5, 0.45,-0.5,0.5, 0.5, 0.5},
+		fixed = { -0.5, 0.45, -0.5, 0.5, 0.5, 0.5 },
 	},
-})
+} )
 
 
 if travelnet.travelnet_effect_enabled then
-	minetest.register_entity( 'travelnet:effect', {
+	minetest.register_entity( "travelnet:effect", {
 		hp_max = 1,
 		physical = false,
 		weight = 5,
-		collisionbox = {-0.4,-0.5,-0.4, 0.4,1.5,0.4},
+		collisionbox = { -0.4, -0.5, -0.4, 0.4, 1.5, 0.4 },
 		visual = "upright_sprite",
-		visual_size = {x=1, y=2},
+		visual_size = { x = 1, y = 2 },
 		textures = { "travelnet_flash.png" }, -- number of required textures depends on visual
-		spritediv = {x=1, y=1},
-		initial_sprite_basepos = {x=0, y=0},
+		spritediv = { x = 1, y = 1 },
+		initial_sprite_basepos = { x = 0, y = 0 },
 		is_visible = true,
 		makes_footstep_sound = false,
 		automatic_rotate = true,
 
 		anz_rotations = 0,
 
-		on_step = function(self)
+		on_step = function( self )
 			-- this is supposed to be more flickering than smooth animation
-			self.object:set_yaw( self.object:get_yaw()+1)
+			self.object:set_yaw( self.object:get_yaw() + 1 )
 			self.anz_rotations = self.anz_rotations + 1
 			-- eventually self-destruct
 			if self.anz_rotations > 15 then
 				self.object:remove()
 			end
 		end
-	})
+	} )
 end
 
 
 if travelnet.travelnet_enabled then
 	-- register-functions for travelnet nodes
-	dofile(travelnet.path.."/register_travelnet.lua")
+	dofile( travelnet.path.."/register_travelnet.lua" )
 	-- default travelnet registrations
-	dofile(travelnet.path.."/travelnet.lua")
+	dofile( travelnet.path.."/travelnet.lua" )
 end
 if travelnet.elevator_enabled then
-	dofile(travelnet.path.."/elevator.lua")  -- allows up/down transfers only
+	dofile( travelnet.path.."/elevator.lua" )  -- allows up/down transfers only
 end
 if travelnet.doors_enabled then
 	-- doors that open and close automaticly when the travelnet or elevator is used
-	dofile(travelnet.path.."/doors.lua")
+	dofile( travelnet.path.."/doors.lua" )
 end
 
 if travelnet.enable_abm then
 	-- restore travelnet data when players pass by broken networks
-	dofile(travelnet.path.."/restore_network_via_abm.lua")
+	dofile( travelnet.path.."/restore_network_via_abm.lua" )
 end
 
 -- upon server start, read the savefile

--- a/init.lua
+++ b/init.lua
@@ -1,27 +1,27 @@
 
 
 --[[
-    Teleporter networks that allow players to choose a destination out of a list
-    Copyright (C) 2013 Sokomine
+	Teleporter networks that allow players to choose a destination out of a list
+	Copyright (C) 2013 Sokomine
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+	This program is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+	You should have received a copy of the GNU General Public License
+	along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 --]]
 
 -- integration test
 if minetest.settings:get_bool("travelnet.enable_travelnet_integration_test") then
-   dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua")
+	dofile(minetest.get_modpath(minetest.get_current_modname()) .. "/integration_test.lua")
 end
 
 -- Required to save the travelnet data properly in all cases
@@ -29,34 +29,34 @@ if not minetest.safe_file_write then
 	error("[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)")
 end
 
-travelnet = {};
+travelnet = {}
 
-travelnet.targets = {};
+travelnet.targets = {}
 travelnet.path = minetest.get_modpath(minetest.get_current_modname())
 
 -- privs
-dofile(travelnet.path.."/privs.lua");
+dofile(travelnet.path.."/privs.lua")
 
 -- read the configuration
-dofile(travelnet.path.."/config.lua");
+dofile(travelnet.path.."/config.lua")
 
 -- saving / reading
-dofile(travelnet.path.."/persistence.lua");
+dofile(travelnet.path.."/persistence.lua")
 
 -- common functions
-dofile(travelnet.path.."/functions.lua");
+dofile(travelnet.path.."/functions.lua")
 
 -- formspec stuff
-dofile(travelnet.path.."/formspecs.lua");
+dofile(travelnet.path.."/formspecs.lua")
 
 -- travelnet / elevator update
-dofile(travelnet.path.."/update_formspec.lua");
+dofile(travelnet.path.."/update_formspec.lua")
 
 -- add button
-dofile(travelnet.path.."/add_target.lua");
+dofile(travelnet.path.."/add_target.lua")
 
 -- receive fields handler
-dofile(travelnet.path.."/on_receive_fields.lua");
+dofile(travelnet.path.."/on_receive_fields.lua")
 
 -- invisible node to place inside top of travelnet box and elevator
 minetest.register_node("travelnet:hidden_top", {
@@ -80,7 +80,7 @@ minetest.register_node("travelnet:hidden_top", {
 })
 
 
-if( travelnet.travelnet_effect_enabled ) then
+if travelnet.travelnet_effect_enabled then
 	minetest.register_entity( 'travelnet:effect', {
 		hp_max = 1,
 		physical = false,
@@ -99,35 +99,35 @@ if( travelnet.travelnet_effect_enabled ) then
 
 		on_step = function(self)
 			-- this is supposed to be more flickering than smooth animation
-			self.object:set_yaw( self.object:get_yaw()+1);
-			self.anz_rotations = self.anz_rotations + 1;
+			self.object:set_yaw( self.object:get_yaw()+1)
+			self.anz_rotations = self.anz_rotations + 1
 			-- eventually self-destruct
 			if self.anz_rotations > 15 then
-				self.object:remove();
+				self.object:remove()
 			end
 		end
 	})
 end
 
 
-if( travelnet.travelnet_enabled ) then
+if travelnet.travelnet_enabled then
 	-- register-functions for travelnet nodes
-	dofile(travelnet.path.."/register_travelnet.lua");
+	dofile(travelnet.path.."/register_travelnet.lua")
 	-- default travelnet registrations
-	dofile(travelnet.path.."/travelnet.lua");
+	dofile(travelnet.path.."/travelnet.lua")
 end
-if( travelnet.elevator_enabled ) then
-	dofile(travelnet.path.."/elevator.lua");  -- allows up/down transfers only
+if travelnet.elevator_enabled then
+	dofile(travelnet.path.."/elevator.lua")  -- allows up/down transfers only
 end
-if( travelnet.doors_enabled ) then
+if travelnet.doors_enabled then
 	-- doors that open and close automaticly when the travelnet or elevator is used
-	dofile(travelnet.path.."/doors.lua");
+	dofile(travelnet.path.."/doors.lua")
 end
 
-if( travelnet.enable_abm ) then
+if travelnet.enable_abm then
 	-- restore travelnet data when players pass by broken networks
-	dofile(travelnet.path.."/restore_network_via_abm.lua");
+	dofile(travelnet.path.."/restore_network_via_abm.lua")
 end
 
 -- upon server start, read the savefile
-travelnet.restore_data();
+travelnet.restore_data()

--- a/integration_test.lua
+++ b/integration_test.lua
@@ -1,25 +1,25 @@
 
 minetest.log("warning", "[TEST] integration-test enabled!")
 
-minetest.register_on_mods_loaded( function()
-	minetest.after( 1, function()
+minetest.register_on_mods_loaded(function()
+	minetest.after(1, function()
 
-		local data = minetest.write_json( { success = true }, true )
-		local file = io.open( minetest.get_worldpath().."/integration_test.json", "w" )
+		local data = minetest.write_json({ success=true }, true)
+		local file = io.open(minetest.get_worldpath().."/integration_test.json", "w")
 		if file then
-			file:write( data )
+			file:write(data)
 			file:close()
 		end
 
-		file = io.open( minetest.get_worldpath().."/registered_nodes.txt", "w" )
+		file = io.open(minetest.get_worldpath().."/registered_nodes.txt", "w")
 		if file then
 			for name in pairs(minetest.registered_nodes) do
-				file:write( name .. '\n' )
+				file:write(name .. '\n')
 			end
 			file:close()
 		end
 
-		minetest.log( "warning", "[TEST] integration tests done!" )
-		minetest.request_shutdown( "success" )
-	end )
-end )
+		minetest.log("warning", "[TEST] integration tests done!")
+		minetest.request_shutdown("success")
+	end)
+end)

--- a/integration_test.lua
+++ b/integration_test.lua
@@ -1,25 +1,25 @@
 
 minetest.log("warning", "[TEST] integration-test enabled!")
 
-minetest.register_on_mods_loaded(function()
-	minetest.after(1, function()
+minetest.register_on_mods_loaded( function()
+	minetest.after( 1, function()
 
-		local data = minetest.write_json({ success = true }, true)
-		local file = io.open(minetest.get_worldpath().."/integration_test.json", "w" )
+		local data = minetest.write_json( { success = true }, true )
+		local file = io.open( minetest.get_worldpath().."/integration_test.json", "w" )
 		if file then
-			file:write(data)
+			file:write( data )
 			file:close()
 		end
 
-		file = io.open(minetest.get_worldpath().."/registered_nodes.txt", "w" )
+		file = io.open( minetest.get_worldpath().."/registered_nodes.txt", "w" )
 		if file then
 			for name in pairs(minetest.registered_nodes) do
-				file:write(name .. '\n')
+				file:write( name .. '\n' )
 			end
 			file:close()
 		end
 
-		minetest.log("warning", "[TEST] integration tests done!")
-		minetest.request_shutdown("success")
-	end)
-end)
+		minetest.log( "warning", "[TEST] integration tests done!" )
+		minetest.request_shutdown( "success" )
+	end )
+end )

--- a/integration_test.lua
+++ b/integration_test.lua
@@ -4,14 +4,14 @@ minetest.log("warning", "[TEST] integration-test enabled!")
 minetest.register_on_mods_loaded(function()
 	minetest.after(1, function()
 
-		local data = minetest.write_json({ success = true }, true);
-		local file = io.open(minetest.get_worldpath().."/integration_test.json", "w" );
+		local data = minetest.write_json({ success = true }, true)
+		local file = io.open(minetest.get_worldpath().."/integration_test.json", "w" )
 		if file then
 			file:write(data)
 			file:close()
 		end
 
-		file = io.open(minetest.get_worldpath().."/registered_nodes.txt", "w" );
+		file = io.open(minetest.get_worldpath().."/registered_nodes.txt", "w" )
 		if file then
 			for name in pairs(minetest.registered_nodes) do
 				file:write(name .. '\n')

--- a/integration_test.lua
+++ b/integration_test.lua
@@ -14,7 +14,7 @@ minetest.register_on_mods_loaded(function()
 		file = io.open(minetest.get_worldpath() .. "/registered_nodes.txt", "w")
 		if file then
 			for name in pairs(minetest.registered_nodes) do
-				file:write(name .. '\n')
+				file:write(name .. "\n")
 			end
 			file:close()
 		end

--- a/integration_test.lua
+++ b/integration_test.lua
@@ -5,13 +5,13 @@ minetest.register_on_mods_loaded(function()
 	minetest.after(1, function()
 
 		local data = minetest.write_json({ success=true }, true)
-		local file = io.open(minetest.get_worldpath().."/integration_test.json", "w")
+		local file = io.open(minetest.get_worldpath() .. "/integration_test.json", "w")
 		if file then
 			file:write(data)
 			file:close()
 		end
 
-		file = io.open(minetest.get_worldpath().."/registered_nodes.txt", "w")
+		file = io.open(minetest.get_worldpath() .. "/registered_nodes.txt", "w")
 		if file then
 			for name in pairs(minetest.registered_nodes) do
 				file:write(name .. '\n')

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -46,7 +46,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 			minetest.chat_send_player(name,
 				S("This %s belongs to %s. You can't remove it."):format(
 					description,
-					tostring(meta:get_string('owner'))
+					tostring(meta:get_string("owner"))
 				)
 			)
 			return
@@ -144,7 +144,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	end
 
 	local this_node = minetest.get_node(pos)
-	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
+	if this_node ~= nil and this_node.name == "travelnet:elevator" then
 		for k,_ in pairs(travelnet.targets[owner_name][station_network]) do
 			if travelnet.targets[owner_name][station_network][k].nr == fields.target then
 				fields.target = k
@@ -169,7 +169,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"))
 
 	if travelnet.travelnet_sound_enabled then
-		if this_node.name == 'travelnet:elevator' then
+		if this_node.name == "travelnet:elevator" then
 			minetest.sound_play("travelnet_bell", {
 				pos = pos,
 				gain = 0.75,

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -3,11 +3,11 @@ local S = minetest.get_translator("travelnet")
 
 travelnet.on_receive_fields = function(pos, _, fields, player)
 	if not pos then
-		return;
+		return
 	end
 
-	local meta = minetest.get_meta(pos);
-	local name = player:get_player_name();
+	local meta = minetest.get_meta(pos)
+	local name = player:get_player_name()
 
 	-- the player wants to quit/exit the formspec; do not save/update anything
 	if fields and fields.station_exit and fields.station_exit ~= "" then
@@ -16,7 +16,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 
 	-- the player wants to remove the station
 	if fields.station_dig then
-		local owner = meta:get_string( "owner" );
+		local owner = meta:get_string( "owner" )
 		local network_name = meta:get_string("station_network")
 		local node = minetest.get_node(pos)
 		local description
@@ -30,122 +30,121 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 		elseif node and node.name == "locked_travelnet:elevator" then
 			description = "locked elevator"
 		else
-			minetest.chat_send_player(name, "Error: Unknown node.");
+			minetest.chat_send_player(name, "Error: Unknown node.")
 			return
 		end
 
 		-- players with travelnet_remove priv can dig the station
-		if( not(minetest.check_player_privs(name, {travelnet_remove=true}))
-			-- the function travelnet.allow_dig(..) may allow additional digging
-			and not(travelnet.allow_dig( name, owner, network_name, pos ))
-			-- the owner can remove the station
-			and owner ~= name
-			-- stations without owner can be removed by anybody
-			and owner ~= "") then
-				minetest.chat_send_player(name,
-					S("This %s belongs to %s. You can't remove it."):format(
-						description,
-						tostring( meta:get_string('owner'))
-					)
-				);
-				return
+		if not minetest.check_player_privs(name, {travelnet_remove=true})
+		-- the function travelnet.allow_dig(..) may allow additional digging
+		and not travelnet.allow_dig( name, owner, network_name, pos )
+		-- the owner can remove the station
+		and owner ~= name
+		-- stations without owner can be removed by anybody
+		and owner ~= "" then
+			minetest.chat_send_player(name,
+				S("This %s belongs to %s. You can't remove it."):format(
+					description,
+					tostring( meta:get_string('owner'))
+				)
+			)
+			return
 		end
 
 		-- abort if protected by another mod
-		if( minetest.is_protected(pos, name)
-			and not(minetest.check_player_privs(name, {protection_bypass=true})) ) then
-				minetest.record_protection_violation(pos, name)
-				return
+		if minetest.is_protected(pos, name)
+		and not(minetest.check_player_privs(name, {protection_bypass=true})) then
+			minetest.record_protection_violation(pos, name)
+			return
 		end
 
 		local pinv = player:get_inventory()
 		if not pinv:room_for_item("main", node.name) then
-			minetest.chat_send_player(name, S("You do not have enough room in your inventory."));
+			minetest.chat_send_player(name, S("You do not have enough room in your inventory."))
 			return
 		end
 
 		-- give the player the box
 		pinv:add_item("main", node.name)
 		-- remove the box from the data structure
-		travelnet.remove_box( pos, nil, meta:to_table(), player );
+		travelnet.remove_box( pos, nil, meta:to_table(), player )
 		-- remove the node as such
 		minetest.remove_node(pos)
-		return;
+		return
 	end
 
 
 
 
 	-- if the box has not been configured yet
-	if( meta:get_string("station_network")=="" ) then
-		travelnet.add_target( fields.station_name, fields.station_network, pos, name, meta, fields.owner );
-		return;
+	if meta:get_string("station_network")=="" then
+		travelnet.add_target( fields.station_name, fields.station_network, pos, name, meta, fields.owner )
+		return
 	end
 
-	if( fields.open_door ) then
-		travelnet.open_close_door( pos, player, 0 );
-		return;
+	if fields.open_door then
+		travelnet.open_close_door( pos, player, 0 )
+		return
 	end
 
 	-- the owner or players with the travelnet_attach priv can move stations up or down in the list
-	if( fields.move_up or fields.move_down) then
-		travelnet.update_formspec( pos, name, fields );
-		return;
+	if fields.move_up or fields.move_down then
+		travelnet.update_formspec( pos, name, fields )
+		return
 	end
 
-	if( not( fields.target )) then
-		minetest.chat_send_player(name, S("Please click on the target you want to travel to."));
-		return;
+	if not fields.target then
+		minetest.chat_send_player(name, S("Please click on the target you want to travel to."))
+		return
 	end
 
 
 	-- if there is something wrong with the data
-	local owner_name      = meta:get_string( "owner" );
-	local station_name    = meta:get_string( "station_name" );
-	local station_network = meta:get_string( "station_network" );
+	local owner_name      = meta:get_string( "owner" )
+	local station_name    = meta:get_string( "station_name" )
+	local station_network = meta:get_string( "station_network" )
 
-	if(  not( owner_name  )
-		or not( station_name )
-		or not( station_network )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
+	if not owner_name
+	or not station_name
+	or not station_network
+	or not travelnet.targets[ owner_name ]
+	or not travelnet.targets[ owner_name ][ station_network ] then
 
-			if owner_name
-				and station_name
-				and station_network then
-					travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name );
-				else
-					minetest.chat_send_player(name, S("Error")..": "..
-						S("There is something wrong with the configuration of this station.")..
-						" DEBUG DATA: owner: "..(  owner_name or "?")..
-						" station_name: "..(station_name or "?")..
-						" station_network: "..(station_network or "?").."."
-					);
-				return
-			end
-	end
-
-	if(  not( owner_name )
-		or not( station_network )
-		or not( travelnet.targets )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )) then
+		if owner_name
+		and station_name
+		and station_network then
+			travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
+		else
 			minetest.chat_send_player(name, S("Error")..": "..
-				S("This travelnet is lacking data and/or improperly configured."));
-				print( "ERROR: The travelnet at "..minetest.pos_to_string( pos ).." has a problem: "..
-				" DATA: owner: "..(  owner_name or "?")..
+				S("There is something wrong with the configuration of this station.")..
+				" DEBUG DATA: owner: "..(  owner_name or "?")..
 				" station_name: "..(station_name or "?")..
 				" station_network: "..(station_network or "?").."."
-			);
-		return;
+			)
+			return
+		end
 	end
 
-	local this_node = minetest.get_node( pos );
+	if not owner_name
+	or not station_network
+	or not travelnet.targets
+	or not travelnet.targets[ owner_name ]
+	or not travelnet.targets[ owner_name ][ station_network ] then
+		minetest.chat_send_player(name, S("Error")..": "..
+			S("This travelnet is lacking data and/or improperly configured."))
+			print( "ERROR: The travelnet at "..minetest.pos_to_string( pos ).." has a problem: "..
+			" DATA: owner: "..(  owner_name or "?")..
+			" station_name: "..(station_name or "?")..
+			" station_network: "..(station_network or "?").."."
+		)
+		return
+	end
+
+	local this_node = minetest.get_node( pos )
 	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
 		for k,_ in pairs( travelnet.targets[ owner_name ][ station_network ] ) do
-			if( travelnet.targets[ owner_name ][ station_network ][ k ].nr
-			== fields.target) then
-				fields.target = k;
+			if travelnet.targets[ owner_name ][ station_network ][ k ].nr == fields.target then
+				fields.target = k
 			end
 		end
 	end
@@ -154,40 +153,38 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	if not travelnet.targets[ owner_name ][ station_network ][ fields.target ] then
 		minetest.chat_send_player(name, S("Station '@1' does not exist (anymore?)" ..
 			" " .. "on this network.", fields.target or "?")
-		);
-		travelnet.update_formspec( pos, name, nil );
-		return;
+		)
+		travelnet.update_formspec( pos, name, nil )
+		return
 	end
 
 
-	if( not( travelnet.allow_travel( name, owner_name, station_network, station_name, fields.target ))) then
-		return;
+	if not travelnet.allow_travel( name, owner_name, station_network, station_name, fields.target ) then
+		return
 	end
-	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"));
-
-
+	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"))
 
 	if travelnet.travelnet_sound_enabled then
 		if this_node.name == 'travelnet:elevator' then
-			minetest.sound_play("travelnet_bell", {pos = pos, gain = 0.75, max_hear_distance = 10,});
+			minetest.sound_play("travelnet_bell", {pos = pos, gain = 0.75, max_hear_distance = 10,})
 		else
-			minetest.sound_play("travelnet_travel", {pos = pos, gain = 0.75, max_hear_distance = 10,});
+			minetest.sound_play("travelnet_travel", {pos = pos, gain = 0.75, max_hear_distance = 10,})
 		end
 	end
 
 	if travelnet.travelnet_effect_enabled then
-		minetest.add_entity( {x=pos.x,y=pos.y+0.5,z=pos.z}, "travelnet:effect"); -- it self-destructs after 20 turns
+		minetest.add_entity( {x=pos.x,y=pos.y+0.5,z=pos.z}, "travelnet:effect") -- it self-destructs after 20 turns
 	end
 
 	-- close the doors at the sending station
-	travelnet.open_close_door( pos, player, 1 );
+	travelnet.open_close_door( pos, player, 1 )
 
 	-- transport the player to the target location
 
 	-- may be 0.0 for some versions of MT 5 player model
-	local player_model_bottom = tonumber(minetest.settings:get("player_model_bottom")) or -.5;
-	local player_model_vec = vector.new(0, player_model_bottom, 0);
-	local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos;
+	local player_model_bottom = tonumber(minetest.settings:get("player_model_bottom")) or -.5
+	local player_model_vec = vector.new(0, player_model_bottom, 0)
+	local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos
 
 	local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
 	local top_node = minetest.get_node(top_pos)
@@ -198,10 +195,10 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 		end
 	end
 
-	player:move_to( vector.add(target_pos, player_model_vec), false);
+	player:move_to( vector.add(target_pos, player_model_vec), false)
 
 	-- check if the box has at the other end has been removed.
-	local node2 = minetest.get_node_or_nil(target_pos);
+	local node2 = minetest.get_node_or_nil(target_pos)
 	if node2 ~= nil then
 		local node2_def = minetest.registered_nodes[node2.name]
 		local has_travelnet_group = node2_def.groups.travelnet or node2_def.groups.elevator
@@ -216,9 +213,9 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 				}
 			}
 
-			travelnet.remove_box( target_pos, nil, oldmetadata, player );
+			travelnet.remove_box( target_pos, nil, oldmetadata, player )
 			-- send the player back as there's no receiving travelnet
-			player:move_to( pos, false );
+			player:move_to( pos, false )
 		else
 			travelnet.rotate_player( target_pos, player, 0 )
 		end

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -35,13 +35,14 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 		end
 
 		-- players with travelnet_remove priv can dig the station
-		if not minetest.check_player_privs(name, { travelnet_remove=true })
-		-- the function travelnet.allow_dig(..) may allow additional digging
-		and not travelnet.allow_dig(name, owner, network_name, pos)
-		-- the owner can remove the station
-		and owner ~= name
-		-- stations without owner can be removed by anybody
-		and owner ~= "" then
+		if	    not minetest.check_player_privs(name, { travelnet_remove=true })
+			-- the function travelnet.allow_dig(..) may allow additional digging
+			and not travelnet.allow_dig(name, owner, network_name, pos)
+			-- the owner can remove the station
+			and owner ~= name
+			-- stations without owner can be removed by anybody
+			and owner ~= ""
+		then
 			minetest.chat_send_player(name,
 				S("This %s belongs to %s. You can't remove it."):format(
 					description,
@@ -52,8 +53,9 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 		end
 
 		-- abort if protected by another mod
-		if minetest.is_protected(pos, name)
-		and not(minetest.check_player_privs(name, { protection_bypass=true })) then
+		if	minetest.is_protected(pos, name)
+			and not minetest.check_player_privs(name, { protection_bypass=true })
+		then
 			minetest.record_protection_violation(pos, name)
 			return
 		end
@@ -72,8 +74,6 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 		minetest.remove_node(pos)
 		return
 	end
-
-
 
 
 	-- if the box has not been configured yet
@@ -104,39 +104,42 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	local station_name    = meta:get_string("station_name")
 	local station_network = meta:get_string("station_network")
 
-	if not owner_name
-	or not station_name
-	or not station_network
-	or not travelnet.targets[owner_name]
-	or not travelnet.targets[owner_name][station_network] then
-
-		if owner_name
-		and station_name
-		and station_network then
+	if	   not owner_name
+		or not station_name
+		or not station_network
+		or not travelnet.targets[owner_name]
+		or not travelnet.targets[owner_name][station_network]
+	then
+		if	    owner_name
+			and station_name
+			and station_network
+		then
 			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
 		else
-			minetest.chat_send_player(name, S("Error")..": "..
-				S("There is something wrong with the configuration of this station.")..
-				" DEBUG DATA: owner: "..(owner_name or "?")..
-				" station_name: "..(station_name or "?")..
-				" station_network: "..(station_network or "?").."."
+			minetest.chat_send_player(name, S("Error") .. ": " ..
+				S("There is something wrong with the configuration of this station.") ..
+					" DEBUG DATA: owner: " .. (owner_name or "?") ..
+					" station_name: " .. (station_name or "?") ..
+					" station_network: " .. (station_network or "?") .. "."
 			)
 			return
 		end
 	end
 
-	if not owner_name
-	or not station_network
-	or not travelnet.targets
-	or not travelnet.targets[owner_name]
-	or not travelnet.targets[owner_name][station_network] then
-		minetest.chat_send_player(name, S("Error")..": "..
+	if	   not owner_name
+		or not station_network
+		or not travelnet.targets
+		or not travelnet.targets[owner_name]
+		or not travelnet.targets[owner_name][station_network]
+	then
+		minetest.chat_send_player(name, S("Error") .. ": " ..
 			S("This travelnet is lacking data and/or improperly configured."))
-			print("ERROR: The travelnet at "..minetest.pos_to_string(pos).." has a problem: "..
-			" DATA: owner: "..(owner_name or "?")..
-			" station_name: "..(station_name or "?")..
-			" station_network: "..(station_network or "?").."."
-		)
+			print(
+				"ERROR: The travelnet at " .. minetest.pos_to_string(pos) .. " has a problem: " ..
+				" DATA: owner: " .. (owner_name or "?") ..
+				" station_name: " .. (station_name or "?") ..
+				" station_network: " .. (station_network or "?") .. "."
+			)
 		return
 	end
 
@@ -151,8 +154,9 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 
 	-- if the target station is gone
 	if not travelnet.targets[owner_name][station_network][fields.target] then
-		minetest.chat_send_player(name, S("Station '@1' does not exist (anymore?)" ..
-			" " .. "on this network.", fields.target or "?")
+		minetest.chat_send_player(name,
+				S("Station '@1' does not exist (anymore?)" ..
+					" " .. "on this network.", fields.target or "?")
 		)
 		travelnet.update_formspec(pos, name, nil)
 		return

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -1,12 +1,12 @@
 local S = minetest.get_translator("travelnet")
 
 
-travelnet.on_receive_fields = function( pos, _, fields, player )
+travelnet.on_receive_fields = function(pos, _, fields, player)
 	if not pos then
 		return
 	end
 
-	local meta = minetest.get_meta( pos )
+	local meta = minetest.get_meta(pos)
 	local name = player:get_player_name()
 
 	-- the player wants to quit/exit the formspec; do not save/update anything
@@ -16,60 +16,60 @@ travelnet.on_receive_fields = function( pos, _, fields, player )
 
 	-- the player wants to remove the station
 	if fields.station_dig then
-		local owner = meta:get_string( "owner" )
-		local network_name = meta:get_string( "station_network" )
-		local node = minetest.get_node( pos )
+		local owner = meta:get_string("owner")
+		local network_name = meta:get_string("station_network")
+		local node = minetest.get_node(pos)
 		local description
 
-		if node and minetest.get_item_group( node.name, "travelnet" ) == 1 then
+		if node and minetest.get_item_group(node.name, "travelnet") == 1 then
 			description = "travelnet box"
-		elseif node and minetest.get_item_group( node.name, "elevator" ) == 1 then
+		elseif node and minetest.get_item_group(node.name, "elevator") == 1 then
 			description = "elevator"
 		elseif node and node.name == "locked_travelnet:travelnet" then
 			description = "locked travelnet"
 		elseif node and node.name == "locked_travelnet:elevator" then
 			description = "locked elevator"
 		else
-			minetest.chat_send_player( name, "Error: Unknown node." )
+			minetest.chat_send_player(name, "Error: Unknown node.")
 			return
 		end
 
 		-- players with travelnet_remove priv can dig the station
-		if not minetest.check_player_privs( name, { travelnet_remove = true } )
+		if not minetest.check_player_privs(name, { travelnet_remove=true })
 		-- the function travelnet.allow_dig(..) may allow additional digging
-		and not travelnet.allow_dig( name, owner, network_name, pos )
+		and not travelnet.allow_dig(name, owner, network_name, pos)
 		-- the owner can remove the station
 		and owner ~= name
 		-- stations without owner can be removed by anybody
 		and owner ~= "" then
-			minetest.chat_send_player( name,
+			minetest.chat_send_player(name,
 				S("This %s belongs to %s. You can't remove it."):format(
 					description,
-					tostring( meta:get_string('owner'))
+					tostring(meta:get_string('owner'))
 				)
 			)
 			return
 		end
 
 		-- abort if protected by another mod
-		if minetest.is_protected( pos, name )
-		and not(minetest.check_player_privs( name, { protection_bypass = true }) ) then
-			minetest.record_protection_violation( pos, name )
+		if minetest.is_protected(pos, name)
+		and not(minetest.check_player_privs(name, { protection_bypass=true })) then
+			minetest.record_protection_violation(pos, name)
 			return
 		end
 
 		local pinv = player:get_inventory()
-		if not pinv:room_for_item( "main", node.name ) then
-			minetest.chat_send_player( name, S("You do not have enough room in your inventory.") )
+		if not pinv:room_for_item("main", node.name) then
+			minetest.chat_send_player(name, S("You do not have enough room in your inventory."))
 			return
 		end
 
 		-- give the player the box
-		pinv:add_item( "main", node.name )
+		pinv:add_item("main", node.name)
 		-- remove the box from the data structure
-		travelnet.remove_box( pos, nil, meta:to_table(), player )
+		travelnet.remove_box(pos, nil, meta:to_table(), player)
 		-- remove the node as such
-		minetest.remove_node( pos )
+		minetest.remove_node(pos)
 		return
 	end
 
@@ -77,45 +77,45 @@ travelnet.on_receive_fields = function( pos, _, fields, player )
 
 
 	-- if the box has not been configured yet
-	if meta:get_string( "station_network" )=="" then
-		travelnet.add_target( fields.station_name, fields.station_network, pos, name, meta, fields.owner )
+	if meta:get_string("station_network") == "" then
+		travelnet.add_target(fields.station_name, fields.station_network, pos, name, meta, fields.owner)
 		return
 	end
 
 	if fields.open_door then
-		travelnet.open_close_door( pos, player, 0 )
+		travelnet.open_close_door(pos, player, 0)
 		return
 	end
 
 	-- the owner or players with the travelnet_attach priv can move stations up or down in the list
 	if fields.move_up or fields.move_down then
-		travelnet.update_formspec( pos, name, fields )
+		travelnet.update_formspec(pos, name, fields)
 		return
 	end
 
 	if not fields.target then
-		minetest.chat_send_player( name, S("Please click on the target you want to travel to.") )
+		minetest.chat_send_player(name, S("Please click on the target you want to travel to."))
 		return
 	end
 
 
 	-- if there is something wrong with the data
-	local owner_name      = meta:get_string( "owner" )
-	local station_name    = meta:get_string( "station_name" )
-	local station_network = meta:get_string( "station_network" )
+	local owner_name      = meta:get_string("owner")
+	local station_name    = meta:get_string("station_name")
+	local station_network = meta:get_string("station_network")
 
 	if not owner_name
 	or not station_name
 	or not station_network
-	or not travelnet.targets[ owner_name ]
-	or not travelnet.targets[ owner_name ][ station_network ] then
+	or not travelnet.targets[owner_name]
+	or not travelnet.targets[owner_name][station_network] then
 
 		if owner_name
 		and station_name
 		and station_network then
-			travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
+			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
 		else
-			minetest.chat_send_player( name, S("Error")..": "..
+			minetest.chat_send_player(name, S("Error")..": "..
 				S("There is something wrong with the configuration of this station.")..
 				" DEBUG DATA: owner: "..(owner_name or "?")..
 				" station_name: "..(station_name or "?")..
@@ -128,11 +128,11 @@ travelnet.on_receive_fields = function( pos, _, fields, player )
 	if not owner_name
 	or not station_network
 	or not travelnet.targets
-	or not travelnet.targets[ owner_name ]
-	or not travelnet.targets[ owner_name ][ station_network ] then
-		minetest.chat_send_player( name, S("Error")..": "..
+	or not travelnet.targets[owner_name]
+	or not travelnet.targets[owner_name][station_network] then
+		minetest.chat_send_player(name, S("Error")..": "..
 			S("This travelnet is lacking data and/or improperly configured."))
-			print( "ERROR: The travelnet at "..minetest.pos_to_string( pos ).." has a problem: "..
+			print("ERROR: The travelnet at "..minetest.pos_to_string(pos).." has a problem: "..
 			" DATA: owner: "..(owner_name or "?")..
 			" station_name: "..(station_name or "?")..
 			" station_network: "..(station_network or "?").."."
@@ -140,67 +140,75 @@ travelnet.on_receive_fields = function( pos, _, fields, player )
 		return
 	end
 
-	local this_node = minetest.get_node( pos )
+	local this_node = minetest.get_node(pos)
 	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
-		for k,_ in pairs( travelnet.targets[ owner_name ][ station_network ] ) do
-			if travelnet.targets[ owner_name ][ station_network ][ k ].nr == fields.target then
+		for k,_ in pairs(travelnet.targets[owner_name][station_network]) do
+			if travelnet.targets[owner_name][station_network][k].nr == fields.target then
 				fields.target = k
 			end
 		end
 	end
 
 	-- if the target station is gone
-	if not travelnet.targets[ owner_name ][ station_network ][ fields.target ] then
+	if not travelnet.targets[owner_name][station_network][fields.target] then
 		minetest.chat_send_player(name, S("Station '@1' does not exist (anymore?)" ..
 			" " .. "on this network.", fields.target or "?")
 		)
-		travelnet.update_formspec( pos, name, nil )
+		travelnet.update_formspec(pos, name, nil)
 		return
 	end
 
 
-	if not travelnet.allow_travel( name, owner_name, station_network, station_name, fields.target ) then
+	if not travelnet.allow_travel(name, owner_name, station_network, station_name, fields.target) then
 		return
 	end
-	minetest.chat_send_player( name, S("Initiating transfer to station '@1'.", fields.target or "?") )
+	minetest.chat_send_player(name, S("Initiating transfer to station '@1'.", fields.target or "?"))
 
 	if travelnet.travelnet_sound_enabled then
 		if this_node.name == 'travelnet:elevator' then
-			minetest.sound_play( "travelnet_bell", { pos = pos, gain = 0.75, max_hear_distance = 10 } )
+			minetest.sound_play("travelnet_bell", {
+				pos = pos,
+				gain = 0.75,
+				max_hear_distance = 10
+			})
 		else
-			minetest.sound_play( "travelnet_travel", { pos = pos, gain = 0.75, max_hear_distance = 10 } )
+			minetest.sound_play("travelnet_travel", {
+				pos = pos,
+				gain = 0.75,
+				max_hear_distance = 10
+			})
 		end
 	end
 
 	if travelnet.travelnet_effect_enabled then
-		minetest.add_entity( { x = pos.x, y = pos.y + 0.5, z = pos.z }, "travelnet:effect" ) -- it self-destructs after 20 turns
+		minetest.add_entity({ x=pos.x, y=pos.y + 0.5, z=pos.z }, "travelnet:effect") -- it self-destructs after 20 turns
 	end
 
 	-- close the doors at the sending station
-	travelnet.open_close_door( pos, player, 1 )
+	travelnet.open_close_door(pos, player, 1)
 
 	-- transport the player to the target location
 
 	-- may be 0.0 for some versions of MT 5 player model
-	local player_model_bottom = tonumber( minetest.settings:get( "player_model_bottom" ) ) or -.5
-	local player_model_vec = vector.new( 0, player_model_bottom, 0 )
-	local target_pos = travelnet.targets[ owner_name ][ station_network ][ fields.target ].pos
+	local player_model_bottom = tonumber(minetest.settings:get("player_model_bottom")) or -.5
+	local player_model_vec = vector.new(0, player_model_bottom, 0)
+	local target_pos = travelnet.targets[owner_name][station_network][fields.target].pos
 
-	local top_pos = { x = pos.x, y = pos.y+1, z = pos.z }
-	local top_node = minetest.get_node( top_pos )
+	local top_pos = { x=pos.x, y=pos.y+1, z=pos.z }
+	local top_node = minetest.get_node(top_pos)
 	if top_node.name ~= "travelnet:hidden_top" then
-		local def = minetest.registered_nodes[ top_node.name ]
+		local def = minetest.registered_nodes[top_node.name]
 		if def and def.buildable_to then
-			minetest.set_node( top_pos, { name = "travelnet:hidden_top" } )
+			minetest.set_node(top_pos, { name="travelnet:hidden_top" })
 		end
 	end
 
-	player:move_to( vector.add( target_pos, player_model_vec ), false)
+	player:move_to(vector.add(target_pos, player_model_vec), false)
 
 	-- check if the box has at the other end has been removed.
-	local node2 = minetest.get_node_or_nil( target_pos )
+	local node2 = minetest.get_node_or_nil(target_pos)
 	if node2 ~= nil then
-		local node2_def = minetest.registered_nodes[ node2.name ]
+		local node2_def = minetest.registered_nodes[node2.name]
 		local has_travelnet_group = node2_def.groups.travelnet or node2_def.groups.elevator
 
 		if not has_travelnet_group then
@@ -213,11 +221,11 @@ travelnet.on_receive_fields = function( pos, _, fields, player )
 				}
 			}
 
-			travelnet.remove_box( target_pos, nil, oldmetadata, player )
+			travelnet.remove_box(target_pos, nil, oldmetadata, player)
 			-- send the player back as there's no receiving travelnet
-			player:move_to( pos, false )
+			player:move_to(pos, false)
 		else
-			travelnet.rotate_player( target_pos, player, 0 )
+			travelnet.rotate_player(target_pos, player, 0)
 		end
 	end
 end

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -117,10 +117,10 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
 		else
 			minetest.chat_send_player(name, S("Error") .. ": " ..
-				S("There is something wrong with the configuration of this station.") ..
-					" DEBUG DATA: owner: " .. (owner_name or "?") ..
-					" station_name: " .. (station_name or "?") ..
-					" station_network: " .. (station_network or "?") .. "."
+					S("There is something wrong with the configuration of this station.") ..
+						" DEBUG DATA: owner: " .. (owner_name or "?") ..
+						" station_name: " .. (station_name or "?") ..
+						" station_network: " .. (station_network or "?") .. "."
 			)
 			return
 		end
@@ -185,7 +185,7 @@ travelnet.on_receive_fields = function(pos, _, fields, player)
 	end
 
 	if travelnet.travelnet_effect_enabled then
-		minetest.add_entity({ x=pos.x, y=pos.y + 0.5, z=pos.z }, "travelnet:effect") -- it self-destructs after 20 turns
+		minetest.add_entity({ x=pos.x, y=pos.y + 0.5, z=pos.z }, "travelnet:effect")  -- it self-destructs after 20 turns
 	end
 
 	-- close the doors at the sending station

--- a/persistence.lua
+++ b/persistence.lua
@@ -1,6 +1,6 @@
 local S = minetest.get_translator("travelnet")
 
-local mod_data_path = minetest.get_worldpath().."/mod_travelnet.data"
+local mod_data_path = minetest.get_worldpath() .. "/mod_travelnet.data"
 
 -- called whenever a station is added or removed
 travelnet.save_data = function()
@@ -24,9 +24,9 @@ travelnet.restore_data = function()
 	travelnet.targets = minetest.deserialize(data)
 
 	if not travelnet.targets then
-		local backup_file = mod_data_path..".bak"
+		local backup_file = mod_data_path .. ".bak"
 		print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-			"Saved the backup as '@2'.", mod_data_path, backup_file))
+					"Saved the backup as '@2'.", mod_data_path, backup_file))
 
 		minetest.safe_file_write(backup_file, data)
 		travelnet.targets = {}

--- a/persistence.lua
+++ b/persistence.lua
@@ -9,7 +9,7 @@ travelnet.save_data = function()
 
 	local success = minetest.safe_file_write( mod_data_path, data )
 	if not success then
-		print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path))
+		print( S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path) )
 	end
 end
 
@@ -18,17 +18,17 @@ travelnet.restore_data = function()
 
 	local file = io.open( mod_data_path, "r" )
 	if not file then
-		print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path))
+		print( S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path) )
 		return
 	end
 
-	local data = file:read("*all")
+	local data = file:read( "*all" )
 	travelnet.targets = minetest.deserialize( data )
 
 	if not travelnet.targets then
 		local backup_file = mod_data_path..".bak"
-		print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-			"Saved the backup as '@2'.", mod_data_path, backup_file))
+		print( S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
+			"Saved the backup as '@2'.", mod_data_path, backup_file) )
 
 		minetest.safe_file_write( backup_file, data )
 		travelnet.targets = {}

--- a/persistence.lua
+++ b/persistence.lua
@@ -26,7 +26,7 @@ travelnet.restore_data = function()
 	if not travelnet.targets then
 		local backup_file = mod_data_path .. ".bak"
 		print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-					"Saved the backup as '@2'.", mod_data_path, backup_file))
+				"Saved the backup as '@2'.", mod_data_path, backup_file))
 
 		minetest.safe_file_write(backup_file, data)
 		travelnet.targets = {}

--- a/persistence.lua
+++ b/persistence.lua
@@ -4,33 +4,31 @@ local mod_data_path = minetest.get_worldpath().."/mod_travelnet.data"
 
 -- called whenever a station is added or removed
 travelnet.save_data = function()
+	local data = minetest.serialize(travelnet.targets)
 
-	local data = minetest.serialize( travelnet.targets )
-
-	local success = minetest.safe_file_write( mod_data_path, data )
+	local success = minetest.safe_file_write(mod_data_path, data)
 	if not success then
-		print( S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path) )
+		print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path))
 	end
 end
 
 
 travelnet.restore_data = function()
-
-	local file = io.open( mod_data_path, "r" )
+	local file = io.open(mod_data_path, "r")
 	if not file then
-		print( S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path) )
+		print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path))
 		return
 	end
 
-	local data = file:read( "*all" )
-	travelnet.targets = minetest.deserialize( data )
+	local data = file:read("*all")
+	travelnet.targets = minetest.deserialize(data)
 
 	if not travelnet.targets then
 		local backup_file = mod_data_path..".bak"
-		print( S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-			"Saved the backup as '@2'.", mod_data_path, backup_file) )
+		print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
+			"Saved the backup as '@2'.", mod_data_path, backup_file))
 
-		minetest.safe_file_write( backup_file, data )
+		minetest.safe_file_write(backup_file, data)
 		travelnet.targets = {}
 	end
 	file:close()

--- a/persistence.lua
+++ b/persistence.lua
@@ -5,33 +5,33 @@ local mod_data_path = minetest.get_worldpath().."/mod_travelnet.data"
 -- called whenever a station is added or removed
 travelnet.save_data = function()
 
-   local data = minetest.serialize( travelnet.targets );
+	local data = minetest.serialize( travelnet.targets )
 
-   local success = minetest.safe_file_write( mod_data_path, data );
-   if( not success ) then
-      print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path));
-   end
+	local success = minetest.safe_file_write( mod_data_path, data )
+	if not success then
+		print(S("[Mod travelnet] Error: Savefile '@1' could not be written.", mod_data_path))
+	end
 end
 
 
 travelnet.restore_data = function()
 
-   local file = io.open( mod_data_path, "r" );
-   if( not file ) then
-      print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path));
-      return;
-   end
+	local file = io.open( mod_data_path, "r" )
+	if not file then
+		print(S("[Mod travelnet] Error: Savefile '@1' not found.", mod_data_path))
+		return
+	end
 
-   local data = file:read("*all");
-   travelnet.targets = minetest.deserialize( data );
+	local data = file:read("*all")
+	travelnet.targets = minetest.deserialize( data )
 
-   if( not travelnet.targets ) then
-       local backup_file = mod_data_path..".bak"
-       print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
-       "Saved the backup as '@2'.", mod_data_path, backup_file));
+	if not travelnet.targets then
+		local backup_file = mod_data_path..".bak"
+		print(S("[Mod travelnet] Error: Savefile '@1' is damaged." .. " " ..
+			"Saved the backup as '@2'.", mod_data_path, backup_file))
 
-       minetest.safe_file_write( backup_file, data );
-       travelnet.targets = {};
-   end
-   file:close();
+		minetest.safe_file_write( backup_file, data )
+		travelnet.targets = {}
+	end
+	file:close()
 end

--- a/privs.lua
+++ b/privs.lua
@@ -1,11 +1,11 @@
 local S = minetest.get_translator("travelnet")
 
-minetest.register_privilege( "travelnet_attach", {
+minetest.register_privilege("travelnet_attach", {
 	description = S("allows to attach travelnet boxes to travelnets of other players"),
 	give_to_singleplayer = false
-} )
+})
 
-minetest.register_privilege( "travelnet_remove", {
+minetest.register_privilege("travelnet_remove", {
 	description = S("allows to dig travelnet boxes which belog to nets of other players"),
 	give_to_singleplayer = false
-} )
+})

--- a/privs.lua
+++ b/privs.lua
@@ -1,11 +1,11 @@
 local S = minetest.get_translator("travelnet")
 
-minetest.register_privilege("travelnet_attach", {
+minetest.register_privilege( "travelnet_attach", {
 	description = S("allows to attach travelnet boxes to travelnets of other players"),
 	give_to_singleplayer = false
-});
+} )
 
-minetest.register_privilege("travelnet_remove", {
+minetest.register_privilege( "travelnet_remove", {
 	description = S("allows to dig travelnet boxes which belog to nets of other players"),
 	give_to_singleplayer = false
-});
+} )

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -52,9 +52,9 @@ function travelnet.register_travelnet_box(cfg)
 		},
 		light_source = cfg.light_source or 10,
 		after_place_node  = function(pos, placer)
-			local meta = minetest.get_meta(pos);
-			travelnet.reset_formspec( meta );
-			meta:set_string("owner", placer:get_player_name());
+			local meta = minetest.get_meta(pos)
+			travelnet.reset_formspec( meta )
+			meta:set_string("owner", placer:get_player_name())
 			local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
 			minetest.set_node(top_pos, {name="travelnet:hidden_top"})
 		end,
@@ -88,7 +88,7 @@ function travelnet.register_travelnet_box(cfg)
 		-- taken from VanessaEs homedecor fridge
 		on_place = function(itemstack, placer, pointed_thing)
 
-			local pos = pointed_thing.above;
+			local pos = pointed_thing.above
 			local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
 			local def = minetest.registered_nodes[node.name]
 			-- leftover top nodes can be removed by placing a new travelnet underneath
@@ -97,9 +97,9 @@ function travelnet.register_travelnet_box(cfg)
 					placer:get_player_name(),
 					S('Not enough vertical space to place the travelnet box!')
 				)
-				return;
+				return
 			end
-			return minetest.item_place(itemstack, placer, pointed_thing);
+			return minetest.item_place(itemstack, placer, pointed_thing)
 		end,
 
 		on_destruct = function(pos)

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -10,15 +10,15 @@ local S = minetest.get_translator("travelnet")
 local travelnet_dyes = {}
 
 -- travelnet box register function
-function travelnet.register_travelnet_box( cfg )
-	minetest.register_node( cfg.nodename, {
+function travelnet.register_travelnet_box(cfg)
+	minetest.register_node(cfg.nodename, {
 		description = S("Travelnet-Box"),
 		drawtype = "mesh",
 		mesh = "travelnet.obj",
 		sunlight_propagates = true,
 		paramtype = 'light',
 		paramtype2 = "facedir",
-		wield_scale = { x = 0.6, y = 0.6, z = 0.6 },
+		wield_scale = { x=0.6, y=0.6, z=0.6 },
 		selection_box = {
 			type = "fixed",
 			fixed = { -0.5, -0.5, -0.5, 0.5, 1.5, 0.5 }
@@ -31,9 +31,9 @@ function travelnet.register_travelnet_box( cfg )
 				{ -0.5 , -0.5, 0.45,  0.45, 1.45, 0.5 },
 				{ -0.5,  -0.5, -0.5, -0.45, 1.45, 0.5 },
 				--groundplate to stand on
-				{ -0.5, -0.5, -0.5, 0.5, -0.45, 0.5 },
+				{ -0.5,  -0.5, -0.5,  0.5, -0.45, 0.5 },
 				--roof
-				{ -0.5, 1.45, -0.5, 0.5,   1.5, 0.5 },
+				{ -0.5,  1.45, -0.5,  0.5,   1.5, 0.5 },
 			},
 		},
 
@@ -51,46 +51,46 @@ function travelnet.register_travelnet_box( cfg )
 			travelnet = 1
 		},
 		light_source = cfg.light_source or 10,
-		after_place_node  = function( pos, placer )
-			local meta = minetest.get_meta( pos )
-			travelnet.reset_formspec( meta )
-			meta:set_string( "owner", placer:get_player_name() )
-			local top_pos = { x = pos.x, y = pos.y + 1, z = pos.z }
-			minetest.set_node( top_pos, { name = "travelnet:hidden_top" } )
+		after_place_node  = function(pos, placer)
+			local meta = minetest.get_meta(pos)
+			travelnet.reset_formspec(meta)
+			meta:set_string("owner", placer:get_player_name())
+			local top_pos = { x=pos.x, y=pos.y+1, z=pos.z }
+			minetest.set_node(top_pos, { name="travelnet:hidden_top" })
 		end,
 
 		on_receive_fields = travelnet.on_receive_fields,
-		on_punch = function( pos, node, puncher )
+		on_punch = function(pos, node, puncher)
 			local item = puncher:get_wielded_item()
-			if travelnet_dyes[ item:get_name() ] and puncher:get_player_control().sneak
-					and not minetest.is_protected( pos, puncher:get_player_name() ) then
+			if travelnet_dyes[item:get_name()] and puncher:get_player_control().sneak
+					and not minetest.is_protected(pos, puncher:get_player_name()) then
 				-- in-place travelnet coloring
-				node.name = travelnet_dyes[ item:get_name() ]
-				minetest.swap_node( pos, node )
+				node.name = travelnet_dyes[item:get_name()]
+				minetest.swap_node(pos, node)
 				item:take_item()
-				puncher:set_wielded_item( item )
+				puncher:set_wielded_item(item)
 				return
 			end
-			travelnet.update_formspec( pos, puncher:get_player_name(), nil )
+			travelnet.update_formspec(pos, puncher:get_player_name(), nil)
 		end,
 
-		can_dig = function( pos, player )
-			return travelnet.can_dig( pos, player, 'travelnet box' )
+		can_dig = function(pos, player)
+			return travelnet.can_dig(pos, player, 'travelnet box')
 		end,
 
-		after_dig_node = function( pos, oldnode, oldmetadata, digger )
-			travelnet.remove_box( pos, oldnode, oldmetadata, digger )
+		after_dig_node = function(pos, oldnode, oldmetadata, digger)
+			travelnet.remove_box(pos, oldnode, oldmetadata, digger)
 		end,
 
 		-- TNT and overenthusiastic DMs do not destroy travelnets
 		on_blast = function() end,
 
 		-- taken from VanessaEs homedecor fridge
-		on_place = function( itemstack, placer, pointed_thing )
+		on_place = function(itemstack, placer, pointed_thing)
 
 			local pos = pointed_thing.above
-			local node = minetest.get_node( { x = pos.x, y = pos.y + 1, z = pos.z } )
-			local def = minetest.registered_nodes[ node.name ]
+			local node = minetest.get_node({ x=pos.x, y=pos.y+1, z=pos.z })
+			local def = minetest.registered_nodes[node.name]
 			-- leftover top nodes can be removed by placing a new travelnet underneath
 			if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
 				minetest.chat_send_player(
@@ -99,29 +99,29 @@ function travelnet.register_travelnet_box( cfg )
 				)
 				return
 			end
-			return minetest.item_place( itemstack, placer, pointed_thing )
+			return minetest.item_place(itemstack, placer, pointed_thing)
 		end,
 
-		on_destruct = function( pos )
-			pos = { x = pos.x, y = pos.y + 1, z = pos.z }
-			minetest.remove_node( pos )
+		on_destruct = function(pos)
+			pos = { x=pos.x, y=pos.y+1, z=pos.z }
+			minetest.remove_node(pos)
 		end
-	} )
+	})
 
 	if cfg.recipe then
 		-- normal recipe
-		minetest.register_craft( {
+		minetest.register_craft({
 			output = cfg.nodename,
 			recipe = cfg.recipe,
-		} )
+		})
 	end
 	if cfg.dye then
-		travelnet_dyes[ cfg.dye ] = cfg.nodename
+		travelnet_dyes[cfg.dye] = cfg.nodename
 		-- dye recipe
-		minetest.register_craft( {
+		minetest.register_craft({
 			output = cfg.nodename,
 			type = "shapeless",
 			recipe = {"group:travelnet", cfg.dye},
-		} )
+		})
 	end
 end

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -38,20 +38,20 @@ function travelnet.register_travelnet_box(cfg)
 		},
 
 		tiles = {
-			"(travelnet_travelnet_front_color.png^[multiply:"..cfg.color..")^travelnet_travelnet_front.png",  -- backward view
-			"(travelnet_travelnet_back_color.png^[multiply:"..cfg.color..")^travelnet_travelnet_back.png", -- front view
-			"(travelnet_travelnet_side_color.png^[multiply:"..cfg.color..")^travelnet_travelnet_side.png", -- sides :)
-			"travelnet_top.png",  -- view from top
-			"travelnet_bottom.png",  -- view from bottom
+			"(travelnet_travelnet_front_color.png^[multiply:" .. cfg.color .. ")^travelnet_travelnet_front.png", -- backward view
+			"(travelnet_travelnet_back_color.png^[multiply:"  .. cfg.color .. ")^travelnet_travelnet_back.png",  -- front view
+			"(travelnet_travelnet_side_color.png^[multiply:"  .. cfg.color .. ")^travelnet_travelnet_side.png",  -- sides :)
+			"travelnet_top.png", -- view from top
+			"travelnet_bottom.png", -- view from bottom
 		},
 
 		use_texture_alpha = "clip",
-		inventory_image = "travelnet_inv_base.png^(travelnet_inv_colorable.png^[multiply:"..cfg.color..")",
+		inventory_image = "travelnet_inv_base.png^(travelnet_inv_colorable.png^[multiply:" .. cfg.color .. ")",
 		groups = {
 			travelnet = 1
 		},
 		light_source = cfg.light_source or 10,
-		after_place_node  = function(pos, placer)
+		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
 			travelnet.reset_formspec(meta)
 			meta:set_string("owner", placer:get_player_name())
@@ -62,8 +62,10 @@ function travelnet.register_travelnet_box(cfg)
 		on_receive_fields = travelnet.on_receive_fields,
 		on_punch = function(pos, node, puncher)
 			local item = puncher:get_wielded_item()
-			if travelnet_dyes[item:get_name()] and puncher:get_player_control().sneak
-					and not minetest.is_protected(pos, puncher:get_player_name()) then
+			if	    travelnet_dyes[item:get_name()]
+				and puncher:get_player_control().sneak
+				and not minetest.is_protected(pos, puncher:get_player_name())
+			then
 				-- in-place travelnet coloring
 				node.name = travelnet_dyes[item:get_name()]
 				minetest.swap_node(pos, node)
@@ -87,7 +89,6 @@ function travelnet.register_travelnet_box(cfg)
 
 		-- taken from VanessaEs homedecor fridge
 		on_place = function(itemstack, placer, pointed_thing)
-
 			local pos = pointed_thing.above
 			local node = minetest.get_node({ x=pos.x, y=pos.y+1, z=pos.z })
 			local def = minetest.registered_nodes[node.name]
@@ -121,7 +122,7 @@ function travelnet.register_travelnet_box(cfg)
 		minetest.register_craft({
 			output = cfg.nodename,
 			type = "shapeless",
-			recipe = {"group:travelnet", cfg.dye},
+			recipe = { "group:travelnet", cfg.dye },
 		})
 	end
 end

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -16,7 +16,7 @@ function travelnet.register_travelnet_box(cfg)
 		drawtype = "mesh",
 		mesh = "travelnet.obj",
 		sunlight_propagates = true,
-		paramtype = 'light',
+		paramtype = "light",
 		paramtype2 = "facedir",
 		wield_scale = { x=0.6, y=0.6, z=0.6 },
 		selection_box = {
@@ -77,7 +77,7 @@ function travelnet.register_travelnet_box(cfg)
 		end,
 
 		can_dig = function(pos, player)
-			return travelnet.can_dig(pos, player, 'travelnet box')
+			return travelnet.can_dig(pos, player, "travelnet box")
 		end,
 
 		after_dig_node = function(pos, oldnode, oldmetadata, digger)
@@ -96,7 +96,7 @@ function travelnet.register_travelnet_box(cfg)
 			if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
 				minetest.chat_send_player(
 					placer:get_player_name(),
-					S('Not enough vertical space to place the travelnet box!')
+					S("Not enough vertical space to place the travelnet box!")
 				)
 				return
 			end

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -10,15 +10,15 @@ local S = minetest.get_translator("travelnet")
 local travelnet_dyes = {}
 
 -- travelnet box register function
-function travelnet.register_travelnet_box(cfg)
-	minetest.register_node(cfg.nodename, {
+function travelnet.register_travelnet_box( cfg )
+	minetest.register_node( cfg.nodename, {
 		description = S("Travelnet-Box"),
 		drawtype = "mesh",
 		mesh = "travelnet.obj",
 		sunlight_propagates = true,
 		paramtype = 'light',
 		paramtype2 = "facedir",
-		wield_scale = {x=0.6, y=0.6, z=0.6},
+		wield_scale = { x = 0.6, y = 0.6, z = 0.6 },
 		selection_box = {
 			type = "fixed",
 			fixed = { -0.5, -0.5, -0.5, 0.5, 1.5, 0.5 }
@@ -27,13 +27,13 @@ function travelnet.register_travelnet_box(cfg)
 		collision_box = {
 			type = "fixed",
 			fixed = {
-				{ 0.45, -0.5,-0.5,  0.5,  1.45, 0.5},
-				{-0.5 , -0.5, 0.45, 0.45, 1.45, 0.5},
-				{-0.5,  -0.5,-0.5 ,-0.45, 1.45, 0.5},
+				{ 0.45,  -0.5, -0.5,   0.5, 1.45, 0.5 },
+				{ -0.5 , -0.5, 0.45,  0.45, 1.45, 0.5 },
+				{ -0.5,  -0.5, -0.5, -0.45, 1.45, 0.5 },
 				--groundplate to stand on
-				{ -0.5,-0.5,-0.5,0.5,-0.45, 0.5},
+				{ -0.5, -0.5, -0.5, 0.5, -0.45, 0.5 },
 				--roof
-				{ -0.5, 1.45,-0.5,0.5, 1.5, 0.5},
+				{ -0.5, 1.45, -0.5, 0.5,   1.5, 0.5 },
 			},
 		},
 
@@ -51,34 +51,34 @@ function travelnet.register_travelnet_box(cfg)
 			travelnet = 1
 		},
 		light_source = cfg.light_source or 10,
-		after_place_node  = function(pos, placer)
-			local meta = minetest.get_meta(pos)
+		after_place_node  = function( pos, placer )
+			local meta = minetest.get_meta( pos )
 			travelnet.reset_formspec( meta )
-			meta:set_string("owner", placer:get_player_name())
-			local top_pos = {x=pos.x, y=pos.y+1, z=pos.z}
-			minetest.set_node(top_pos, {name="travelnet:hidden_top"})
+			meta:set_string( "owner", placer:get_player_name() )
+			local top_pos = { x = pos.x, y = pos.y + 1, z = pos.z }
+			minetest.set_node( top_pos, { name = "travelnet:hidden_top" } )
 		end,
 
 		on_receive_fields = travelnet.on_receive_fields,
-		on_punch = function(pos, node, puncher)
+		on_punch = function( pos, node, puncher )
 			local item = puncher:get_wielded_item()
-			if travelnet_dyes[item:get_name()] and puncher:get_player_control().sneak
-					and not minetest.is_protected(pos, puncher:get_player_name()) then
+			if travelnet_dyes[ item:get_name() ] and puncher:get_player_control().sneak
+					and not minetest.is_protected( pos, puncher:get_player_name() ) then
 				-- in-place travelnet coloring
-				node.name = travelnet_dyes[item:get_name()]
-				minetest.swap_node(pos, node)
+				node.name = travelnet_dyes[ item:get_name() ]
+				minetest.swap_node( pos, node )
 				item:take_item()
-				puncher:set_wielded_item(item)
+				puncher:set_wielded_item( item )
 				return
 			end
-			travelnet.update_formspec(pos, puncher:get_player_name(), nil)
+			travelnet.update_formspec( pos, puncher:get_player_name(), nil )
 		end,
 
 		can_dig = function( pos, player )
 			return travelnet.can_dig( pos, player, 'travelnet box' )
 		end,
 
-		after_dig_node = function(pos, oldnode, oldmetadata, digger)
+		after_dig_node = function( pos, oldnode, oldmetadata, digger )
 			travelnet.remove_box( pos, oldnode, oldmetadata, digger )
 		end,
 
@@ -86,11 +86,11 @@ function travelnet.register_travelnet_box(cfg)
 		on_blast = function() end,
 
 		-- taken from VanessaEs homedecor fridge
-		on_place = function(itemstack, placer, pointed_thing)
+		on_place = function( itemstack, placer, pointed_thing )
 
 			local pos = pointed_thing.above
-			local node = minetest.get_node({x=pos.x, y=pos.y+1, z=pos.z})
-			local def = minetest.registered_nodes[node.name]
+			local node = minetest.get_node( { x = pos.x, y = pos.y + 1, z = pos.z } )
+			local def = minetest.registered_nodes[ node.name ]
 			-- leftover top nodes can be removed by placing a new travelnet underneath
 			if (not def or not def.buildable_to) and node.name ~= "travelnet:hidden_top" then
 				minetest.chat_send_player(
@@ -99,29 +99,29 @@ function travelnet.register_travelnet_box(cfg)
 				)
 				return
 			end
-			return minetest.item_place(itemstack, placer, pointed_thing)
+			return minetest.item_place( itemstack, placer, pointed_thing )
 		end,
 
-		on_destruct = function(pos)
-			pos = {x=pos.x, y=pos.y+1, z=pos.z}
-			minetest.remove_node(pos)
+		on_destruct = function( pos )
+			pos = { x = pos.x, y = pos.y + 1, z = pos.z }
+			minetest.remove_node( pos )
 		end
-	})
+	} )
 
 	if cfg.recipe then
 		-- normal recipe
-		minetest.register_craft({
+		minetest.register_craft( {
 			output = cfg.nodename,
 			recipe = cfg.recipe,
-		})
+		} )
 	end
 	if cfg.dye then
-		travelnet_dyes[cfg.dye] = cfg.nodename
+		travelnet_dyes[ cfg.dye ] = cfg.nodename
 		-- dye recipe
-		minetest.register_craft({
+		minetest.register_craft( {
 			output = cfg.nodename,
 			type = "shapeless",
 			recipe = {"group:travelnet", cfg.dye},
-		})
+		} )
 	end
 end

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -9,15 +9,19 @@ minetest.register_abm({
 		local station_name    = meta:get_string("station_name")
 		local station_network = meta:get_string("station_network")
 
-		if owner_name and station_name and station_network
-		and (not travelnet.targets
-		or not travelnet.targets[owner_name]
-		or not travelnet.targets[owner_name][station_network]
-		or not travelnet.targets[owner_name][station_network][station_name])
+		if	    owner_name
+			and station_name
+			and station_network
+			and (
+				   not travelnet.targets
+				or not travelnet.targets[owner_name]
+				or not travelnet.targets[owner_name][station_network]
+				or not travelnet.targets[owner_name][station_network][station_name]
+			)
 		then
 			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
-			print('TRAVELNET: re-adding '..tostring(station_name)..' to '..
-			tostring(station_network)..' owned by '..tostring(owner_name))
+			print('TRAVELNET: re-adding ' .. tostring(station_name) .. ' to ' ..
+					tostring(station_network) .. ' owned by ' .. tostring(owner_name))
 		end
 	end
 })

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -3,21 +3,21 @@ minetest.register_abm({
 	nodenames = { "travelnet:travelnet" },
 	interval = 20,
 	chance = 1,
-	action = function( pos )
-		local meta = minetest.get_meta( pos )
-		local owner_name      = meta:get_string( "owner" )
-		local station_name    = meta:get_string( "station_name" )
-		local station_network = meta:get_string( "station_network" )
+	action = function(pos)
+		local meta = minetest.get_meta(pos)
+		local owner_name      = meta:get_string("owner")
+		local station_name    = meta:get_string("station_name")
+		local station_network = meta:get_string("station_network")
 
 		if owner_name and station_name and station_network
-		and ( not travelnet.targets
-		or not travelnet.targets[ owner_name ]
-		or not travelnet.targets[ owner_name ][ station_network ]
-		or not travelnet.targets[ owner_name ][ station_network ][ station_name ] )
+		and (not travelnet.targets
+		or not travelnet.targets[owner_name]
+		or not travelnet.targets[owner_name][station_network]
+		or not travelnet.targets[owner_name][station_network][station_name])
 		then
-			travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
-			print( 'TRAVELNET: re-adding '..tostring( station_name )..' to '..
-			tostring( station_network )..' owned by '..tostring( owner_name ))
+			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
+			print('TRAVELNET: re-adding '..tostring(station_name)..' to '..
+			tostring(station_network)..' owned by '..tostring(owner_name))
 		end
 	end
 })

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -20,8 +20,8 @@ minetest.register_abm({
 			)
 		then
 			travelnet.add_target(station_name, station_network, pos, owner_name, meta, owner_name)
-			print('TRAVELNET: re-adding ' .. tostring(station_name) .. ' to ' ..
-					tostring(station_network) .. ' owned by ' .. tostring(owner_name))
+			print("TRAVELNET: re-adding " .. tostring(station_name) .. " to " ..
+					tostring(station_network) .. " owned by " .. tostring(owner_name))
 		end
 	end
 })

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -4,20 +4,20 @@ minetest.register_abm({
 	interval = 20,
 	chance = 1,
 	action = function(pos)
-		local meta = minetest.get_meta( pos );
-		local owner_name      = meta:get_string( "owner" );
-		local station_name    = meta:get_string( "station_name" );
-		local station_network = meta:get_string( "station_network" );
+		local meta = minetest.get_meta( pos )
+		local owner_name      = meta:get_string( "owner" )
+		local station_name    = meta:get_string( "station_name" )
+		local station_network = meta:get_string( "station_network" )
 
-		if( owner_name and station_name and station_network
-			and ( not( travelnet.targets )
-			or not( travelnet.targets[ owner_name ] )
-			or not( travelnet.targets[ owner_name ][ station_network ] )
-			or not( travelnet.targets[ owner_name ][ station_network ][ station_name ] ))) then
-
-				travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name );
-				print( 'TRAVELNET: re-adding '..tostring( station_name )..' to '..
-				tostring( station_network )..' owned by '..tostring( owner_name ));
+		if owner_name and station_name and station_network
+		and ( not( travelnet.targets )
+		or not( travelnet.targets[ owner_name ] )
+		or not( travelnet.targets[ owner_name ][ station_network ] )
+		or not( travelnet.targets[ owner_name ][ station_network ][ station_name ] ))
+		then
+			travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
+			print( 'TRAVELNET: re-adding '..tostring( station_name )..' to '..
+			tostring( station_network )..' owned by '..tostring( owner_name ))
 		end
 	end
 })

--- a/restore_network_via_abm.lua
+++ b/restore_network_via_abm.lua
@@ -1,19 +1,19 @@
 
 minetest.register_abm({
-	nodenames = {"travelnet:travelnet"},
+	nodenames = { "travelnet:travelnet" },
 	interval = 20,
 	chance = 1,
-	action = function(pos)
+	action = function( pos )
 		local meta = minetest.get_meta( pos )
 		local owner_name      = meta:get_string( "owner" )
 		local station_name    = meta:get_string( "station_name" )
 		local station_network = meta:get_string( "station_network" )
 
 		if owner_name and station_name and station_network
-		and ( not( travelnet.targets )
-		or not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )
-		or not( travelnet.targets[ owner_name ][ station_network ][ station_name ] ))
+		and ( not travelnet.targets
+		or not travelnet.targets[ owner_name ]
+		or not travelnet.targets[ owner_name ][ station_network ]
+		or not travelnet.targets[ owner_name ][ station_network ][ station_name ] )
 		then
 			travelnet.add_target( station_name, station_network, pos, owner_name, meta, owner_name )
 			print( 'TRAVELNET: re-adding '..tostring( station_name )..' to '..

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -1,40 +1,40 @@
 
 -- "default" travelnet box in yellow
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet",
 	recipe = travelnet.travelnet_recipe,
 	color = "#e0bb2d",
 	dye = "dye:yellow"
-})
+} )
 
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet_red",
 	color = "#ce1a1a",
 	dye = "dye:red"
-})
+} )
 
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet_blue",
 	color = "#0051c5",
 	dye = "dye:blue"
-})
+} )
 
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet_green",
 	color = "#53c41c",
 	dye = "dye:green"
-})
+} )
 
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet_black",
 	color = "#0f0f0f",
 	dye = "dye:black",
 	light_source = 0
-})
+} )
 
-travelnet.register_travelnet_box({
+travelnet.register_travelnet_box( {
 	nodename = "travelnet:travelnet_white",
 	color = "#ffffff",
 	dye = "dye:white",
 	light_source = 14
-})
+} )

--- a/travelnet.lua
+++ b/travelnet.lua
@@ -1,40 +1,40 @@
 
 -- "default" travelnet box in yellow
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet",
 	recipe = travelnet.travelnet_recipe,
 	color = "#e0bb2d",
 	dye = "dye:yellow"
-} )
+})
 
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet_red",
 	color = "#ce1a1a",
 	dye = "dye:red"
-} )
+})
 
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet_blue",
 	color = "#0051c5",
 	dye = "dye:blue"
-} )
+})
 
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet_green",
 	color = "#53c41c",
 	dye = "dye:green"
-} )
+})
 
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet_black",
 	color = "#0f0f0f",
 	dye = "dye:black",
 	light_source = 0
-} )
+})
 
-travelnet.register_travelnet_box( {
+travelnet.register_travelnet_box({
 	nodename = "travelnet:travelnet_white",
 	color = "#ffffff",
 	dye = "dye:white",
 	light_source = 14
-} )
+})

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -2,71 +2,73 @@ local S = minetest.get_translator("travelnet")
 
 -- called "on_punch" of travelnet and elevator
 travelnet.update_formspec = function( pos, puncher_name, fields )
-	local meta = minetest.get_meta(pos);
+	local meta = minetest.get_meta(pos)
 
-	local this_node   = minetest.get_node( pos );
-	local is_elevator = false;
+	local this_node   = minetest.get_node( pos )
+	local is_elevator = false
 
 	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
-		is_elevator = true;
+		is_elevator = true
 	end
 
 	if not meta then
-		return;
+		return
 	end
 
-	local owner_name      = meta:get_string( "owner" );
-	local station_name    = meta:get_string( "station_name" );
-	local station_network = meta:get_string( "station_network" );
+	local owner_name      = meta:get_string( "owner" )
+	local station_name    = meta:get_string( "station_name" )
+	local station_network = meta:get_string( "station_network" )
 
-	if(  not( owner_name )
-		or not( station_name ) or station_network == ''
-		or not( station_network )) then
+	if not owner_name
+	or not station_name or station_network == ''
+	or not station_network
+	then
 
 		if is_elevator then
-			travelnet.add_target( nil, nil, pos, puncher_name, meta, owner_name );
-			return;
+			travelnet.add_target( nil, nil, pos, puncher_name, meta, owner_name )
+			return
 		end
 
-		travelnet.reset_formspec( meta );
-		travelnet.show_message( pos, puncher_name, "Error", S("Update failed! Resetting this box on the travelnet."));
-		return;
+		travelnet.reset_formspec( meta )
+		travelnet.show_message( pos, puncher_name, "Error", S("Update failed! Resetting this box on the travelnet."))
+		return
 	end
 
 	-- if the station got lost from the network for some reason (savefile corrupted?) then add it again
-	if(  not( travelnet.targets[ owner_name ] )
-		or not( travelnet.targets[ owner_name ][ station_network ] )
-		or not( travelnet.targets[ owner_name ][ station_network ][ station_name ] )) then
+	if not travelnet.targets[ owner_name ]
+	or not travelnet.targets[ owner_name ][ station_network ]
+	or not travelnet.targets[ owner_name ][ station_network ][ station_name ]
+	then
 
 		-- first one by this player?
 		if not travelnet.targets[owner_name] then
-			travelnet.targets[owner_name ] = {};
+			travelnet.targets[owner_name ] = {}
 		end
 
 		-- first station on this network?
 		if not travelnet.targets[ owner_name ][ station_network ] then
-			travelnet.targets[owner_name ][ station_network ] = {};
+			travelnet.targets[owner_name ][ station_network ] = {}
 		end
 
 
-		local zeit = meta:get_int("timestamp");
-		if not( zeit) or type(zeit)~="number" or zeit<100000 then
-			zeit = os.time();
+		local zeit = meta:get_int("timestamp")
+		if not zeit or type(zeit)~="number" or zeit<100000 then
+			zeit = os.time()
 		end
 
 		-- add this station
-		travelnet.targets[ owner_name ][ station_network ][ station_name ] = {pos=pos, timestamp=zeit };
+		travelnet.targets[ owner_name ][ station_network ][ station_name ] = {pos=pos, timestamp=zeit }
 
 		minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
 			"has been reattached to the network '@2'.", station_name, station_network)
-		);
-		travelnet.save_data();
+		)
+		travelnet.save_data()
 	end
 
 
 	-- add name of station + network + owner + update-button
-	local zusatzstr = "";
-	local trheight = "10";
+	local zusatzstr = ""
+	local trheight = "10"
 
 	local formspec = "size[12,"..trheight.."]"..
 		"label[3.3,0.0;"..S("Travelnet-Box")..":]".."label[6.3,0.0;"..
@@ -78,41 +80,42 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		"label[0.3,1.2;"..S("Owned by:").."]"..
 		"label[6.3,1.2;"..minetest.formspec_escape(owner_name or "?").."]"..
 		"label[3.3,1.6;"..S("Click on target to travel there:").."]"..
-		zusatzstr;
+		zusatzstr
 
-	local x = 0;
-	local y = 0;
-	local i = 0;
+	local x = 0
+	local y = 0
+	local i = 0
 
 
 	-- collect all station names in a table
-	local stations = {};
+	local stations = {}
 
 	for k in pairs( travelnet.targets[ owner_name ][ station_network ] ) do
-		table.insert( stations, k );
+		table.insert( stations, k )
 	end
 
-	local ground_level = 1;
+	local ground_level = 1
 	if is_elevator then
-		table.sort( stations, function(a,b) return travelnet.targets[ owner_name ][ station_network ][ a ].pos.y >
-		travelnet.targets[ owner_name ][ station_network ][ b ].pos.y  end);
+		table.sort( stations, function(a,b)
+			return travelnet.targets[ owner_name ][ station_network ][ a ].pos.y > travelnet.targets[ owner_name ][ station_network ][ b ].pos.y
+		end)
 		-- find ground level
-		local vgl_timestamp = 999999999999;
+		local vgl_timestamp = 999999999999
 		for index,k in ipairs( stations ) do
 			if not travelnet.targets[ owner_name ][ station_network ][ k ].timestamp then
-				travelnet.targets[ owner_name ][ station_network ][ k ].timestamp = os.time();
+				travelnet.targets[ owner_name ][ station_network ][ k ].timestamp = os.time()
 			end
 			if travelnet.targets[ owner_name ][ station_network ][ k ].timestamp < vgl_timestamp then
-				vgl_timestamp = travelnet.targets[ owner_name ][ station_network ][ k ].timestamp;
-				ground_level  = index;
+				vgl_timestamp = travelnet.targets[ owner_name ][ station_network ][ k ].timestamp
+				ground_level  = index
 			end
 		end
 
 		for index,k in ipairs( stations ) do
-			if( index == ground_level ) then
-				travelnet.targets[ owner_name ][ station_network ][ k ].nr = 'G';
+			if index == ground_level then
+				travelnet.targets[ owner_name ][ station_network ][ k ].nr = 'G'
 			else
-				travelnet.targets[ owner_name ][ station_network ][ k ].nr = tostring( ground_level - index );
+				travelnet.targets[ owner_name ][ station_network ][ k ].nr = tostring( ground_level - index )
 			end
 		end
 	else
@@ -120,94 +123,94 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		table.sort( stations, function(a,b)
 			return travelnet.targets[ owner_name ][ station_network ][ a ].timestamp <
 				travelnet.targets[ owner_name ][ station_network ][ b ].timestamp
-		end);
+		end)
 	end
 
 	-- does the player want to move this station one position up in the list?
 	-- only the owner and players with the travelnet_attach priv can change the order of the list
 	-- Note: With elevators, only the "G"(round) marking is actually moved
-	if( fields
+	if fields
 		and (fields.move_up or fields.move_down)
 		and owner_name
 		and owner_name ~= ""
 		and ((owner_name == puncher_name)
 		or (minetest.check_player_privs(puncher_name, {travelnet_attach=true})))
-	) then
+	then
 
-		local current_pos = -1;
+		local current_pos = -1
 		for index,k in ipairs( stations ) do
-			if( k==station_name ) then
-				current_pos = index;
+			if k==station_name then
+				current_pos = index
 			end
 		end
 
-		local swap_with_pos;
-		if( fields.move_up ) then
-			swap_with_pos = current_pos - 1;
+		local swap_with_pos
+		if fields.move_up then
+			swap_with_pos = current_pos - 1
 		else
-			swap_with_pos = current_pos + 1;
+			swap_with_pos = current_pos + 1
 		end
 		-- handle errors
-		if(     swap_with_pos < 1) then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the first one on the list."));
-			return;
-		elseif( swap_with_pos > #stations ) then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the last one on the list."));
-			return;
+		if swap_with_pos < 1 then
+			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the first one on the list."))
+			return
+		elseif swap_with_pos > #stations then
+			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the last one on the list."))
+			return
 		else
 			-- swap the actual data by which the stations are sorted
-			local old_timestamp = travelnet.targets[ owner_name ][ station_network ][ stations[swap_with_pos]].timestamp;
+			local old_timestamp = travelnet.targets[ owner_name ][ station_network ][ stations[swap_with_pos]].timestamp
 			travelnet.targets[    owner_name ][ station_network ][ stations[swap_with_pos]].timestamp =
-			travelnet.targets[ owner_name ][ station_network ][ stations[current_pos  ]].timestamp;
+			travelnet.targets[ owner_name ][ station_network ][ stations[current_pos  ]].timestamp
 			travelnet.targets[    owner_name ][ station_network ][ stations[current_pos  ]].timestamp =
-			old_timestamp;
+			old_timestamp
 
 			-- for elevators, only the "G"(round) marking is moved; no point in swapping stations
-			if( not( is_elevator )) then
+			if not is_elevator then
 				-- actually swap the stations
-				local old_val = stations[ swap_with_pos ];
-				stations[ swap_with_pos ] = stations[ current_pos ];
-				stations[ current_pos   ] = old_val;
+				local old_val = stations[ swap_with_pos ]
+				stations[ swap_with_pos ] = stations[ current_pos ]
+				stations[ current_pos   ] = old_val
 			end
 
 			-- store the changed order
-			travelnet.save_data();
+			travelnet.save_data()
 		end
 	end
 
 	-- if there are only 8 stations (plus this one), center them in the formspec
 	if #stations < 10 then
-		x = 4;
+		x = 4
 	end
 
 	for _,k in ipairs(stations) do
 		-- check if there is an elevator door in front that needs to be opened
-		local open_door_cmd = false;
-		if( k==station_name ) then
-			open_door_cmd = true;
+		local open_door_cmd = false
+		if k==station_name then
+			open_door_cmd = true
 		end
 
-		if( k ~= station_name or open_door_cmd) then
-			i = i+1;
+		if k ~= station_name or open_door_cmd then
+			i = i+1
 
 			-- new column
 			if y==8 then
-				x = x+4;
-				y = 0;
+				x = x+4
+				y = 0
 			end
 
 			if open_door_cmd then
 				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";1,0.5;open_door;<>]"..
-					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]";
+					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]"
 			elseif( is_elevator ) then
 				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";1,0.5;target;"..
 					tostring( travelnet.targets[ owner_name ][ station_network ][ k ].nr ).."]"..
-					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]";
+					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]"
 			else
-				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";4,0.5;target;"..k.."]";
+				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";4,0.5;target;"..k.."]"
 			end
 
-			y = y+1;
+			y = y+1
 		end
 	end
 
@@ -216,15 +219,15 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		"button_exit[11.3,0.0;1.0,0.5;station_exit;"..S("Exit").."]"..
 		"button_exit[10.0,0.5;2.2,0.7;station_dig;"..S("Remove station").."]"..
 		"button[9.6,1.6;1.4,0.5;move_up;"..S("move up").."]"..
-		"button[10.9,1.6;1.4,0.5;move_down;"..S("move down").."]";
+		"button[10.9,1.6;1.4,0.5;move_down;"..S("move down").."]"
 
-	meta:set_string( "formspec", formspec );
+	meta:set_string( "formspec", formspec )
 
 	meta:set_string( "infotext", S("Station '@1'".." "..
 		"on travelnet '@2' (owned by @3)" .." "..
 		"ready for usage. Right-click to travel, punch to update.",
-		tostring(station_name), tostring(station_network), tostring(owner_name)));
+		tostring(station_name), tostring(station_network), tostring(owner_name)))
 
 	-- show the player the updated formspec
-	travelnet.show_current_formspec( pos, meta, puncher_name );
+	travelnet.show_current_formspec( pos, meta, puncher_name )
 end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -1,10 +1,10 @@
 local S = minetest.get_translator("travelnet")
 
 -- called "on_punch" of travelnet and elevator
-travelnet.update_formspec = function( pos, puncher_name, fields )
-	local meta = minetest.get_meta( pos )
+travelnet.update_formspec = function(pos, puncher_name, fields)
+	local meta = minetest.get_meta(pos)
 
-	local this_node   = minetest.get_node( pos )
+	local this_node   = minetest.get_node(pos)
 	local is_elevator = false
 
 	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
@@ -15,9 +15,9 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		return
 	end
 
-	local owner_name      = meta:get_string( "owner" )
-	local station_name    = meta:get_string( "station_name" )
-	local station_network = meta:get_string( "station_network" )
+	local owner_name      = meta:get_string("owner")
+	local station_name    = meta:get_string("station_name")
+	local station_network = meta:get_string("station_network")
 
 	if not owner_name
 	or not station_name or station_network == ''
@@ -25,29 +25,29 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 	then
 
 		if is_elevator then
-			travelnet.add_target( nil, nil, pos, puncher_name, meta, owner_name )
+			travelnet.add_target(nil, nil, pos, puncher_name, meta, owner_name)
 			return
 		end
 
-		travelnet.reset_formspec( meta )
-		travelnet.show_message( pos, puncher_name, "Error", S("Update failed! Resetting this box on the travelnet."))
+		travelnet.reset_formspec(meta)
+		travelnet.show_message(pos, puncher_name, "Error", S("Update failed! Resetting this box on the travelnet."))
 		return
 	end
 
 	-- if the station got lost from the network for some reason (savefile corrupted?) then add it again
-	if not travelnet.targets[ owner_name ]
-	or not travelnet.targets[ owner_name ][ station_network ]
-	or not travelnet.targets[ owner_name ][ station_network ][ station_name ]
+	if not travelnet.targets[owner_name]
+	or not travelnet.targets[owner_name][station_network]
+	or not travelnet.targets[owner_name][station_network][station_name]
 	then
 
 		-- first one by this player?
-		if not travelnet.targets[ owner_name ] then
-			travelnet.targets[ owner_name ] = {}
+		if not travelnet.targets[owner_name] then
+			travelnet.targets[owner_name] = {}
 		end
 
 		-- first station on this network?
-		if not travelnet.targets[ owner_name ][ station_network ] then
-			travelnet.targets[ owner_name ][ station_network ] = {}
+		if not travelnet.targets[owner_name][station_network] then
+			travelnet.targets[owner_name][station_network] = {}
 		end
 
 
@@ -57,9 +57,9 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		end
 
 		-- add this station
-		travelnet.targets[ owner_name ][ station_network ][ station_name ] = { pos = pos, timestamp = zeit }
+		travelnet.targets[owner_name][station_network][station_name] = { pos = pos, timestamp = zeit }
 
-		minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
+		minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
 			"has been reattached to the network '@2'.", station_name, station_network)
 		)
 		travelnet.save_data()
@@ -74,11 +74,11 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		"label[3.3,0.0;"..S("Travelnet-Box")..":]".."label[6.3,0.0;"..
 		S("Punch box to update target list.").."]"..
 		"label[0.3,0.4;"..S("Name of this station:").."]"..
-		"label[6.3,0.4;"..minetest.formspec_escape( station_name or "?" ).."]"..
+		"label[6.3,0.4;"..minetest.formspec_escape(station_name or "?").."]"..
 		"label[0.3,0.8;"..S("Assigned to Network:").."]" ..
-		"label[6.3,0.8;"..minetest.formspec_escape( station_network or "?" ).."]"..
+		"label[6.3,0.8;"..minetest.formspec_escape(station_network or "?").."]"..
 		"label[0.3,1.2;"..S("Owned by:").."]"..
-		"label[6.3,1.2;"..minetest.formspec_escape( owner_name or "?" ).."]"..
+		"label[6.3,1.2;"..minetest.formspec_escape(owner_name or "?").."]"..
 		"label[3.3,1.6;"..S("Click on target to travel there:").."]"..
 		zusatzstr
 
@@ -90,40 +90,41 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 	-- collect all station names in a table
 	local stations = {}
 
-	for k in pairs( travelnet.targets[ owner_name ][ station_network ] ) do
-		table.insert( stations, k )
+	for k in pairs(travelnet.targets[owner_name][station_network]) do
+		table.insert(stations, k)
 	end
 
 	local ground_level = 1
 	if is_elevator then
-		table.sort( stations, function( a, b )
-			return travelnet.targets[ owner_name ][ station_network ][ a ].pos.y > travelnet.targets[ owner_name ][ station_network ][ b ].pos.y
+		table.sort(stations, function(a, b)
+			return travelnet.targets[owner_name][station_network][a].pos.y >
+					travelnet.targets[owner_name][station_network][b].pos.y
 		end)
 		-- find ground level
 		local vgl_timestamp = 999999999999
-		for index,k in ipairs( stations ) do
-			if not travelnet.targets[ owner_name ][ station_network ][ k ].timestamp then
-				travelnet.targets[ owner_name ][ station_network ][ k ].timestamp = os.time()
+		for index,k in ipairs(stations) do
+			if not travelnet.targets[owner_name][station_network][k].timestamp then
+				travelnet.targets[owner_name][station_network][k].timestamp = os.time()
 			end
-			if travelnet.targets[ owner_name ][ station_network ][ k ].timestamp < vgl_timestamp then
-				vgl_timestamp = travelnet.targets[ owner_name ][ station_network ][ k ].timestamp
+			if travelnet.targets[owner_name][station_network][k].timestamp < vgl_timestamp then
+				vgl_timestamp = travelnet.targets[owner_name][station_network][k].timestamp
 				ground_level  = index
 			end
 		end
 
-		for index,k in ipairs( stations ) do
+		for index,k in ipairs(stations) do
 			if index == ground_level then
-				travelnet.targets[ owner_name ][ station_network ][ k ].nr = 'G'
+				travelnet.targets[owner_name][station_network][k].nr = 'G'
 			else
-				travelnet.targets[ owner_name ][ station_network ][ k ].nr = tostring( ground_level - index )
+				travelnet.targets[owner_name][station_network][k].nr = tostring(ground_level - index)
 			end
 		end
 	else
 		-- sort the table according to the timestamp (=time the station was configured)
-		table.sort( stations, function( a, b )
-			return travelnet.targets[ owner_name ][ station_network ][ a ].timestamp <
-				travelnet.targets[ owner_name ][ station_network ][ b ].timestamp
-		end )
+		table.sort(stations, function(a, b)
+			return travelnet.targets[owner_name][station_network][a].timestamp <
+				travelnet.targets[owner_name][station_network][b].timestamp
+		end)
 	end
 
 	-- does the player want to move this station one position up in the list?
@@ -134,11 +135,11 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		and owner_name
 		and owner_name ~= ""
 		and ((owner_name == puncher_name)
-		or (minetest.check_player_privs( puncher_name, {travelnet_attach=true} )))
+		or (minetest.check_player_privs(puncher_name, { travelnet_attach=true })))
 	then
 
 		local current_pos = -1
-		for index, k in ipairs( stations ) do
+		for index, k in ipairs(stations) do
 			if k == station_name then
 				current_pos = index
 			end
@@ -146,31 +147,31 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 
 		local swap_with_pos
 		if fields.move_up then
-			swap_with_pos = current_pos - 1
+			swap_with_pos = current_pos-1
 		else
-			swap_with_pos = current_pos + 1
+			swap_with_pos = current_pos+1
 		end
 		-- handle errors
 		if swap_with_pos < 1 then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the first one on the list.") )
+			travelnet.show_message(pos, puncher_name, "Info", S("This station is already the first one on the list."))
 			return
 		elseif swap_with_pos > #stations then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the last one on the list.") )
+			travelnet.show_message(pos, puncher_name, "Info", S("This station is already the last one on the list."))
 			return
 		else
 			-- swap the actual data by which the stations are sorted
-			local old_timestamp = travelnet.targets[ owner_name ][ station_network ][ stations[swap_with_pos]].timestamp
-			travelnet.targets[ owner_name ][ station_network ][ stations[ swap_with_pos ] ].timestamp =
-			travelnet.targets[ owner_name ][ station_network ][ stations[ current_pos ] ].timestamp
-			travelnet.targets[ owner_name ][ station_network ][ stations[ current_pos ] ].timestamp =
+			local old_timestamp = travelnet.targets[owner_name][station_network][stations[swap_with_pos]].timestamp
+			travelnet.targets[owner_name][station_network][stations[swap_with_pos]].timestamp =
+			travelnet.targets[owner_name][station_network][stations[current_pos]].timestamp
+			travelnet.targets[owner_name][station_network][stations[current_pos]].timestamp =
 			old_timestamp
 
 			-- for elevators, only the "G"(round) marking is moved; no point in swapping stations
 			if not is_elevator then
 				-- actually swap the stations
-				local old_val = stations[ swap_with_pos ]
-				stations[ swap_with_pos ] = stations[ current_pos ]
-				stations[ current_pos ]   = old_val
+				local old_val = stations[swap_with_pos]
+				stations[swap_with_pos] = stations[current_pos]
+				stations[current_pos]   = old_val
 			end
 
 			-- store the changed order
@@ -195,22 +196,22 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 
 			-- new column
 			if y == 8 then
-				x = x+4
+				x = x + 4
 				y = 0
 			end
 
 			if open_door_cmd then
 				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;open_door;<>]"..
-					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring( k ).."]"
-			elseif( is_elevator ) then
+					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring(k).."]"
+			elseif is_elevator then
 				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;target;"..
-					tostring( travelnet.targets[ owner_name ][ station_network ][ k ].nr ).."]"..
-					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring( k ).."]"
+					tostring(travelnet.targets[owner_name][station_network][k].nr).."]"..
+					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring(k).."]"
 			else
 				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";4,0.5;target;"..k.."]"
 			end
 
-			y = y + 1
+			y = y+1
 		end
 	end
 
@@ -221,13 +222,13 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		"button[9.6,1.6;1.4,0.5;move_up;"..S("move up").."]"..
 		"button[10.9,1.6;1.4,0.5;move_down;"..S("move down").."]"
 
-	meta:set_string( "formspec", formspec )
+	meta:set_string("formspec", formspec)
 
-	meta:set_string( "infotext", S("Station '@1'".." "..
+	meta:set_string("infotext", S("Station '@1'".." "..
 		"on travelnet '@2' (owned by @3)" .." "..
 		"ready for usage. Right-click to travel, punch to update.",
-		tostring( station_name ), tostring( station_network ), tostring( owner_name )) )
+		tostring(station_name), tostring(station_network), tostring(owner_name)))
 
 	-- show the player the updated formspec
-	travelnet.show_current_formspec( pos, meta, puncher_name )
+	travelnet.show_current_formspec(pos, meta, puncher_name)
 end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -19,11 +19,10 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	local station_name    = meta:get_string("station_name")
 	local station_network = meta:get_string("station_network")
 
-	if not owner_name
-	or not station_name or station_network == ''
-	or not station_network
+	if	   not owner_name
+		or not station_name or station_network == ''
+		or not station_network
 	then
-
 		if is_elevator then
 			travelnet.add_target(nil, nil, pos, puncher_name, meta, owner_name)
 			return
@@ -35,11 +34,10 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	end
 
 	-- if the station got lost from the network for some reason (savefile corrupted?) then add it again
-	if not travelnet.targets[owner_name]
-	or not travelnet.targets[owner_name][station_network]
-	or not travelnet.targets[owner_name][station_network][station_name]
+	if	   not travelnet.targets[owner_name]
+		or not travelnet.targets[owner_name][station_network]
+		or not travelnet.targets[owner_name][station_network][station_name]
 	then
-
 		-- first one by this player?
 		if not travelnet.targets[owner_name] then
 			travelnet.targets[owner_name] = {}
@@ -50,16 +48,18 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 			travelnet.targets[owner_name][station_network] = {}
 		end
 
-
 		local zeit = meta:get_int("timestamp")
 		if not zeit or type(zeit) ~= "number" or zeit < 100000 then
 			zeit = os.time()
 		end
 
 		-- add this station
-		travelnet.targets[owner_name][station_network][station_name] = { pos = pos, timestamp = zeit }
+		travelnet.targets[owner_name][station_network][station_name] = {
+			pos = pos,
+			timestamp = zeit
+		}
 
-		minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
+		minetest.chat_send_player(owner_name, S("Station '@1'" .. " " ..
 			"has been reattached to the network '@2'.", station_name, station_network)
 		)
 		travelnet.save_data()
@@ -70,22 +70,21 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	local zusatzstr = ""
 	local trheight = "10"
 
-	local formspec = "size[12,"..trheight.."]"..
-		"label[3.3,0.0;"..S("Travelnet-Box")..":]".."label[6.3,0.0;"..
-		S("Punch box to update target list.").."]"..
-		"label[0.3,0.4;"..S("Name of this station:").."]"..
-		"label[6.3,0.4;"..minetest.formspec_escape(station_name or "?").."]"..
-		"label[0.3,0.8;"..S("Assigned to Network:").."]" ..
-		"label[6.3,0.8;"..minetest.formspec_escape(station_network or "?").."]"..
-		"label[0.3,1.2;"..S("Owned by:").."]"..
-		"label[6.3,1.2;"..minetest.formspec_escape(owner_name or "?").."]"..
-		"label[3.3,1.6;"..S("Click on target to travel there:").."]"..
+	local formspec = "size[12," .. trheight .. "]" ..
+		"label[3.3,0.0;" .. S("Travelnet-Box") .. ":]" .. "label[6.3,0.0;" ..
+		S("Punch box to update target list.") .. "]" ..
+		"label[0.3,0.4;" .. S("Name of this station:") .. "]" ..
+		"label[6.3,0.4;" .. minetest.formspec_escape(station_name or "?") .. "]" ..
+		"label[0.3,0.8;" .. S("Assigned to Network:") .. "]" ..
+		"label[6.3,0.8;" .. minetest.formspec_escape(station_network or "?") .. "]" ..
+		"label[0.3,1.2;" .. S("Owned by:") .. "]" ..
+		"label[6.3,1.2;" .. minetest.formspec_escape(owner_name or "?") .. "]" ..
+		"label[3.3,1.6;" .. S("Click on target to travel there:") .. "]" ..
 		zusatzstr
 
 	local x = 0
 	local y = 0
 	local i = 0
-
 
 	-- collect all station names in a table
 	local stations = {}
@@ -100,6 +99,7 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 			return travelnet.targets[owner_name][station_network][a].pos.y >
 					travelnet.targets[owner_name][station_network][b].pos.y
 		end)
+
 		-- find ground level
 		local vgl_timestamp = 999999999999
 		for index,k in ipairs(stations) do
@@ -130,12 +130,14 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	-- does the player want to move this station one position up in the list?
 	-- only the owner and players with the travelnet_attach priv can change the order of the list
 	-- Note: With elevators, only the "G"(round) marking is actually moved
-	if fields
+	if	    fields
 		and (fields.move_up or fields.move_down)
 		and owner_name
 		and owner_name ~= ""
-		and ((owner_name == puncher_name)
-		or (minetest.check_player_privs(puncher_name, { travelnet_attach=true })))
+		and (
+			   (owner_name == puncher_name)
+			or (minetest.check_player_privs(puncher_name, { travelnet_attach=true }))
+		)
 	then
 
 		local current_pos = -1
@@ -162,9 +164,9 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 			-- swap the actual data by which the stations are sorted
 			local old_timestamp = travelnet.targets[owner_name][station_network][stations[swap_with_pos]].timestamp
 			travelnet.targets[owner_name][station_network][stations[swap_with_pos]].timestamp =
-			travelnet.targets[owner_name][station_network][stations[current_pos]].timestamp
+					travelnet.targets[owner_name][station_network][stations[current_pos]].timestamp
 			travelnet.targets[owner_name][station_network][stations[current_pos]].timestamp =
-			old_timestamp
+					old_timestamp
 
 			-- for elevators, only the "G"(round) marking is moved; no point in swapping stations
 			if not is_elevator then
@@ -201,31 +203,31 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 			end
 
 			if open_door_cmd then
-				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;open_door;<>]"..
-					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring(k).."]"
+				formspec = formspec .. "button_exit[" .. x .. "," .. (y + 2.5) .. ";1,0.5;open_door;<>]" ..
+					"label[" .. (x + 0.9) .. "," .. (y + 2.35) .. ";" .. tostring(k) .. "]"
 			elseif is_elevator then
-				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;target;"..
-					tostring(travelnet.targets[owner_name][station_network][k].nr).."]"..
-					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring(k).."]"
+				formspec = formspec .. "button_exit[" .. x .. "," .. (y + 2.5) .. ";1,0.5;target;" ..
+					tostring(travelnet.targets[owner_name][station_network][k].nr) .. "]" ..
+					"label[" .. (x + 0.9) .. "," .. (y + 2.35) .. ";" .. tostring(k) .. "]"
 			else
-				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";4,0.5;target;"..k.."]"
+				formspec = formspec .. "button_exit[" .. x .. "," .. (y + 2.5) .. ";4,0.5;target;" .. k .. "]"
 			end
 
 			y = y+1
 		end
 	end
 
-	formspec = formspec..
-		"label[8.0,1.6;"..S("Position in list:").."]"..
-		"button_exit[11.3,0.0;1.0,0.5;station_exit;"..S("Exit").."]"..
-		"button_exit[10.0,0.5;2.2,0.7;station_dig;"..S("Remove station").."]"..
-		"button[9.6,1.6;1.4,0.5;move_up;"..S("move up").."]"..
-		"button[10.9,1.6;1.4,0.5;move_down;"..S("move down").."]"
+	formspec = formspec ..
+		"label[8.0,1.6;" .. S("Position in list:") .. "]" ..
+		"button_exit[11.3,0.0;1.0,0.5;station_exit;" .. S("Exit") .. "]" ..
+		"button_exit[10.0,0.5;2.2,0.7;station_dig;" .. S("Remove station") .. "]" ..
+		"button[9.6,1.6;1.4,0.5;move_up;" .. S("move up") .. "]" ..
+		"button[10.9,1.6;1.4,0.5;move_down;" .. S("move down") .. "]"
 
 	meta:set_string("formspec", formspec)
 
-	meta:set_string("infotext", S("Station '@1'".." "..
-		"on travelnet '@2' (owned by @3)" .." "..
+	meta:set_string("infotext", S("Station '@1'" .. " " ..
+		"on travelnet '@2' (owned by @3)" .. " " ..
 		"ready for usage. Right-click to travel, punch to update.",
 		tostring(station_name), tostring(station_network), tostring(owner_name)))
 

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -2,7 +2,7 @@ local S = minetest.get_translator("travelnet")
 
 -- called "on_punch" of travelnet and elevator
 travelnet.update_formspec = function( pos, puncher_name, fields )
-	local meta = minetest.get_meta(pos)
+	local meta = minetest.get_meta( pos )
 
 	local this_node   = minetest.get_node( pos )
 	local is_elevator = false
@@ -41,25 +41,25 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 	then
 
 		-- first one by this player?
-		if not travelnet.targets[owner_name] then
-			travelnet.targets[owner_name ] = {}
+		if not travelnet.targets[ owner_name ] then
+			travelnet.targets[ owner_name ] = {}
 		end
 
 		-- first station on this network?
 		if not travelnet.targets[ owner_name ][ station_network ] then
-			travelnet.targets[owner_name ][ station_network ] = {}
+			travelnet.targets[ owner_name ][ station_network ] = {}
 		end
 
 
 		local zeit = meta:get_int("timestamp")
-		if not zeit or type(zeit)~="number" or zeit<100000 then
+		if not zeit or type(zeit) ~= "number" or zeit < 100000 then
 			zeit = os.time()
 		end
 
 		-- add this station
-		travelnet.targets[ owner_name ][ station_network ][ station_name ] = {pos=pos, timestamp=zeit }
+		travelnet.targets[ owner_name ][ station_network ][ station_name ] = { pos = pos, timestamp = zeit }
 
-		minetest.chat_send_player(owner_name, S("Station '@1'" .." "..
+		minetest.chat_send_player( owner_name, S("Station '@1'" .." "..
 			"has been reattached to the network '@2'.", station_name, station_network)
 		)
 		travelnet.save_data()
@@ -74,11 +74,11 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		"label[3.3,0.0;"..S("Travelnet-Box")..":]".."label[6.3,0.0;"..
 		S("Punch box to update target list.").."]"..
 		"label[0.3,0.4;"..S("Name of this station:").."]"..
-		"label[6.3,0.4;"..minetest.formspec_escape(station_name or "?").."]"..
+		"label[6.3,0.4;"..minetest.formspec_escape( station_name or "?" ).."]"..
 		"label[0.3,0.8;"..S("Assigned to Network:").."]" ..
-		"label[6.3,0.8;"..minetest.formspec_escape(station_network or "?").."]"..
+		"label[6.3,0.8;"..minetest.formspec_escape( station_network or "?" ).."]"..
 		"label[0.3,1.2;"..S("Owned by:").."]"..
-		"label[6.3,1.2;"..minetest.formspec_escape(owner_name or "?").."]"..
+		"label[6.3,1.2;"..minetest.formspec_escape( owner_name or "?" ).."]"..
 		"label[3.3,1.6;"..S("Click on target to travel there:").."]"..
 		zusatzstr
 
@@ -96,7 +96,7 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 
 	local ground_level = 1
 	if is_elevator then
-		table.sort( stations, function(a,b)
+		table.sort( stations, function( a, b )
 			return travelnet.targets[ owner_name ][ station_network ][ a ].pos.y > travelnet.targets[ owner_name ][ station_network ][ b ].pos.y
 		end)
 		-- find ground level
@@ -120,10 +120,10 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		end
 	else
 		-- sort the table according to the timestamp (=time the station was configured)
-		table.sort( stations, function(a,b)
+		table.sort( stations, function( a, b )
 			return travelnet.targets[ owner_name ][ station_network ][ a ].timestamp <
 				travelnet.targets[ owner_name ][ station_network ][ b ].timestamp
-		end)
+		end )
 	end
 
 	-- does the player want to move this station one position up in the list?
@@ -134,12 +134,12 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		and owner_name
 		and owner_name ~= ""
 		and ((owner_name == puncher_name)
-		or (minetest.check_player_privs(puncher_name, {travelnet_attach=true})))
+		or (minetest.check_player_privs( puncher_name, {travelnet_attach=true} )))
 	then
 
 		local current_pos = -1
-		for index,k in ipairs( stations ) do
-			if k==station_name then
+		for index, k in ipairs( stations ) do
+			if k == station_name then
 				current_pos = index
 			end
 		end
@@ -152,17 +152,17 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 		end
 		-- handle errors
 		if swap_with_pos < 1 then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the first one on the list."))
+			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the first one on the list.") )
 			return
 		elseif swap_with_pos > #stations then
-			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the last one on the list."))
+			travelnet.show_message( pos, puncher_name, "Info", S("This station is already the last one on the list.") )
 			return
 		else
 			-- swap the actual data by which the stations are sorted
 			local old_timestamp = travelnet.targets[ owner_name ][ station_network ][ stations[swap_with_pos]].timestamp
-			travelnet.targets[    owner_name ][ station_network ][ stations[swap_with_pos]].timestamp =
-			travelnet.targets[ owner_name ][ station_network ][ stations[current_pos  ]].timestamp
-			travelnet.targets[    owner_name ][ station_network ][ stations[current_pos  ]].timestamp =
+			travelnet.targets[ owner_name ][ station_network ][ stations[ swap_with_pos ] ].timestamp =
+			travelnet.targets[ owner_name ][ station_network ][ stations[ current_pos ] ].timestamp
+			travelnet.targets[ owner_name ][ station_network ][ stations[ current_pos ] ].timestamp =
 			old_timestamp
 
 			-- for elevators, only the "G"(round) marking is moved; no point in swapping stations
@@ -170,7 +170,7 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 				-- actually swap the stations
 				local old_val = stations[ swap_with_pos ]
 				stations[ swap_with_pos ] = stations[ current_pos ]
-				stations[ current_pos   ] = old_val
+				stations[ current_pos ]   = old_val
 			end
 
 			-- store the changed order
@@ -186,7 +186,7 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 	for _,k in ipairs(stations) do
 		-- check if there is an elevator door in front that needs to be opened
 		local open_door_cmd = false
-		if k==station_name then
+		if k == station_name then
 			open_door_cmd = true
 		end
 
@@ -194,23 +194,23 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 			i = i+1
 
 			-- new column
-			if y==8 then
+			if y == 8 then
 				x = x+4
 				y = 0
 			end
 
 			if open_door_cmd then
-				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";1,0.5;open_door;<>]"..
-					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]"
+				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;open_door;<>]"..
+					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring( k ).."]"
 			elseif( is_elevator ) then
-				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";1,0.5;target;"..
+				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";1,0.5;target;"..
 					tostring( travelnet.targets[ owner_name ][ station_network ][ k ].nr ).."]"..
-					"label["..(x+0.9)..","..(y+2.35)..";"..tostring( k ).."]"
+					"label["..(x + 0.9)..","..(y + 2.35)..";"..tostring( k ).."]"
 			else
-				formspec = formspec .."button_exit["..(x)..","..(y+2.5)..";4,0.5;target;"..k.."]"
+				formspec = formspec .."button_exit["..(x)..","..(y + 2.5)..";4,0.5;target;"..k.."]"
 			end
 
-			y = y+1
+			y = y + 1
 		end
 	end
 
@@ -226,7 +226,7 @@ travelnet.update_formspec = function( pos, puncher_name, fields )
 	meta:set_string( "infotext", S("Station '@1'".." "..
 		"on travelnet '@2' (owned by @3)" .." "..
 		"ready for usage. Right-click to travel, punch to update.",
-		tostring(station_name), tostring(station_network), tostring(owner_name)))
+		tostring( station_name ), tostring( station_network ), tostring( owner_name )) )
 
 	-- show the player the updated formspec
 	travelnet.show_current_formspec( pos, meta, puncher_name )

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -7,7 +7,7 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	local this_node   = minetest.get_node(pos)
 	local is_elevator = false
 
-	if this_node ~= nil and this_node.name == 'travelnet:elevator' then
+	if this_node ~= nil and this_node.name == "travelnet:elevator" then
 		is_elevator = true
 	end
 
@@ -20,7 +20,7 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 	local station_network = meta:get_string("station_network")
 
 	if	   not owner_name
-		or not station_name or station_network == ''
+		or not station_name or station_network == ""
 		or not station_network
 	then
 		if is_elevator then
@@ -114,7 +114,7 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 
 		for index,k in ipairs(stations) do
 			if index == ground_level then
-				travelnet.targets[owner_name][station_network][k].nr = 'G'
+				travelnet.targets[owner_name][station_network][k].nr = "G"
 			else
 				travelnet.targets[owner_name][station_network][k].nr = tostring(ground_level - index)
 			end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -59,9 +59,9 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 			timestamp = zeit
 		}
 
-		minetest.chat_send_player(owner_name, S("Station '@1'" .. " " ..
-			"has been reattached to the network '@2'.", station_name, station_network)
-		)
+		minetest.chat_send_player(owner_name,
+				S("Station '@1'" .. " " ..
+					"has been reattached to the network '@2'.", station_name, station_network))
 		travelnet.save_data()
 	end
 
@@ -226,10 +226,11 @@ travelnet.update_formspec = function(pos, puncher_name, fields)
 
 	meta:set_string("formspec", formspec)
 
-	meta:set_string("infotext", S("Station '@1'" .. " " ..
-		"on travelnet '@2' (owned by @3)" .. " " ..
-		"ready for usage. Right-click to travel, punch to update.",
-		tostring(station_name), tostring(station_network), tostring(owner_name)))
+	meta:set_string("infotext",
+			S("Station '@1'" .. " " ..
+				"on travelnet '@2' (owned by @3)" .. " " ..
+				"ready for usage. Right-click to travel, punch to update.",
+				tostring(station_name), tostring(station_network), tostring(owner_name)))
 
 	-- show the player the updated formspec
 	travelnet.show_current_formspec(pos, meta, puncher_name)


### PR DESCRIPTION
**Recommended viewing side-by-side (split) with whitespace changes off** (https://github.com/mt-mods/travelnet/pull/17/files?diff=split&w=1)

The formatting of this mod is a disaster, I have gone through and cleaned it up

This PR should not include any code changes or behaviour changes, the code should not be re-shuffled, simplified or modified in any way, only the formatting aspects should change


- Remove all semicolons - unneeded
- Remove all braces around conditions and around `not` usages - I don't know what language the mod creator came from but it must be horrible
- Make sure indentation is correct
- Replace all indentation variations with tabs
- ~~Maintain any unnecessarily neat formatting, like spaces around arguments or consistent alignment choices~~
- Make formatting consistent with recommendations
- Make whitespace in arguments, object keys etc. consistent
- Make multi-line condition indentation consistent
- ~~Do something about multi-line strings~~ not really, they match recommendations and are pretty consistent but could still be better
- Make multi-line arguments obvious and consistent