### PR TITLE
Load the travelnet node before performing teleport logic on it

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -227,26 +227,6 @@ function travelnet.open_close_door(pos, player, mode)
 	end
 end
 
-local function on_load_internal(target_pos, callback, failure, tries)
-	local target_node = minetest.get_node_or_nil(target_pos)
-	if target_node == nil then
-		if tries < 40 then
-			-- Short delay for the first tries, only try once per second after that for laggy servers
-			local delay = tries < 20 and 0.1 or 1
-			minetest.after(delay, on_load_internal, target_pos, callback, failure, tries+1)
-		elseif type(failure) == 'function' then
-			failure()
-		end
-		return
-	end
-	if type(callback) == 'function' then
-		callback(target_node)
-	end
-end
-travelnet.on_load = function (target_pos, callback, failure)
-	on_load_internal(target_pos, callback, failure, 0)
-end
-
 travelnet.rotate_player = function(target_pos, player)
 	local target_node = minetest.get_node_or_nil(target_pos)
 	if target_node == nil then return end

--- a/functions.lua
+++ b/functions.lua
@@ -231,7 +231,8 @@ local function on_load_internal(target_pos, callback, failure, tries)
 	local target_node = minetest.get_node_or_nil(target_pos)
 	if target_node == nil then
 		if tries < 40 then
-			local delay = tries < 20 and 0.1 or 1 -- Short delay for the first tries, only try once per second after that for laggy servers
+			-- Short delay for the first tries, only try once per second after that for laggy servers
+			local delay = tries < 20 and 0.1 or 1
 			minetest.after(delay, on_load_internal, target_pos, callback, failure, tries+1)
 		elseif type(failure) == 'function' then
 			failure()
@@ -246,7 +247,7 @@ travelnet.on_load = function (target_pos, callback, failure)
 	on_load_internal(target_pos, callback, failure, 0)
 end
 
-travelnet.rotate_player = function(target_pos, player, tries)
+travelnet.rotate_player = function(target_pos, player)
 	local target_node = minetest.get_node_or_nil(target_pos)
 	if target_node == nil then return end
 

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -210,7 +210,7 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 			-- send the player back as there's no receiving travelnet
 			player:move_to(pos, false)
 		else
-			travelnet.rotate_player(target_pos, player, 0)
+			travelnet.rotate_player(target_pos, player)
 		end
 	end, function ()
 		-- Send them back on failure

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -215,7 +215,7 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 	end, function ()
 		-- Send them back on failure
 		player:move_to(pos, false)
-		minetest.chat_send_player(name, S("Teleportation failed. The area could not be loaded."))
+		minetest.chat_send_player(name, S("Transfer failed. The area could not be loaded."))
 	end)
 
 end

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -190,32 +190,27 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 		end
 	end
 
-	player:move_to(vector.add(target_pos, player_model_vec), false)
-	travelnet.on_load(target_pos, function (target_node)
-		-- check if the box has at the other end has been removed.
-		local target_node_def = minetest.registered_nodes[target_node.name]
-		local has_travelnet_group = target_node_def.groups.travelnet or target_node_def.groups.elevator
+	minetest.load_area(target_pos)
 
-		if not has_travelnet_group then
-			-- provide information necessary to identify the removed box
-			local oldmetadata = {
-				fields = {
-					owner           = owner_name,
-					station_name    = fields.target,
-					station_network = station_network
-				}
+	-- check if the box has at the other end has been removed.
+	local target_node = minetest.get_node(target_pos)
+	local target_node_def = minetest.registered_nodes[target_node.name]
+	local has_travelnet_group = target_node_def.groups.travelnet or target_node_def.groups.elevator
+
+	if not has_travelnet_group then
+		-- provide information necessary to identify the removed box
+		local oldmetadata = {
+			fields = {
+				owner           = owner_name,
+				station_name    = fields.target,
+				station_network = station_network
 			}
+		}
 
-			travelnet.remove_box(target_pos, nil, oldmetadata, player)
-			-- send the player back as there's no receiving travelnet
-			player:move_to(pos, false)
-		else
-			travelnet.rotate_player(target_pos, player)
-		end
-	end, function ()
-		-- Send them back on failure
-		player:move_to(pos, false)
-		minetest.chat_send_player(name, S("Transfer failed. The area could not be loaded."))
-	end)
+		travelnet.remove_box(target_pos, nil, oldmetadata, player)
+	else
+		player:move_to(vector.add(target_pos, player_model_vec), false)
+		travelnet.rotate_player(target_pos, player)
+	end
 
 end

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -191,10 +191,8 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 	end
 
 	player:move_to(vector.add(target_pos, player_model_vec), false)
-
-	-- check if the box has at the other end has been removed.
-	local target_node = minetest.get_node_or_nil(target_pos)
-	if target_node ~= nil then
+	travelnet.on_load(target_pos, function (target_node)
+		-- check if the box has at the other end has been removed.
 		local target_node_def = minetest.registered_nodes[target_node.name]
 		local has_travelnet_group = target_node_def.groups.travelnet or target_node_def.groups.elevator
 
@@ -214,6 +212,10 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 		else
 			travelnet.rotate_player(target_pos, player, 0)
 		end
-	end
-end
+	end, function ()
+		-- Send them back on failure
+		player:move_to(pos, false)
+		minetest.chat_send_player(name, S("Teleportation failed. The area could not be loaded."))
+	end)
 
+end


### PR DESCRIPTION
Fixes https://github.com/mt-mods/travelnet/issues/26

Instead of retying the rotate function we should ~~wait until the node  loads first,~~ force the node to load first, then we can do the removal logic if the travelnet no longer exists or the rotate logic if it does.

The way it previously worked meant that the rotate retry logic would never fire, because if the node was found to be `nil` (unloaded) then none of this logic would even run

~~I have also increased the retries to 40 and the delay from 0 to 0.1, since 100ms is fast enough to seem instant and it gives us a longer period of retrying. The second half of them will happen in 1s intervals - this should account for even the worst loading times, retrying for a total of 22s~~