### PR TITLE
Delay opening of notification formspecs

### DIFF
--- a/formspecs.lua
+++ b/formspecs.lua
@@ -21,9 +21,7 @@ function travelnet.show_message(pos, player_name, title, message)
 			S("Exit"),
 			minetest.pos_to_string(pos)
 		)
-	minetest.after(0.1, function ()
-		minetest.show_formspec(player_name, travelnet_form_name, formspec)
-	end)
+		minetest.after(0.1, minetest.show_formspec, player_name, travelnet_form_name, formspec)
 end
 
 -- show the player the formspec they would see when right-clicking the node;
@@ -36,9 +34,7 @@ function travelnet.show_current_formspec(pos, meta, player_name)
 	local formspec = meta:get_string("formspec") ..
 		("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
 	-- show the formspec manually
-	minetest.after(0.1, function ()
-		minetest.show_formspec(player_name, travelnet_form_name, formspec)
-	end)
+	minetest.after(0.1, minetest.show_formspec, player_name, travelnet_form_name, formspec)
 end
 
 -- a player clicked on something in the formspec hse was manually shown

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -10,7 +10,7 @@ function travelnet.show_message(pos, player_name, title, message)
 	local formspec = ([[
 			size[8,3]
 			label[3,0;%s]
-			textlist[0,0.5;8,1.5;;%s;]
+			textarea[0.5,0.5;7,1.5;;%s;]
 			button_exit[3.5,2.5;1.0,0.5;back;%s]
 			button_exit[6.8,2.5;1.0,0.5;station_exit;%s]
 			field[20,20;0.1,0.1;pos2str;Pos;%s]
@@ -21,7 +21,9 @@ function travelnet.show_message(pos, player_name, title, message)
 			S("Exit"),
 			minetest.pos_to_string(pos)
 		)
-	minetest.show_formspec(player_name, travelnet_form_name, formspec)
+	minetest.after(0.1, function ()
+		minetest.show_formspec(player_name, travelnet_form_name, formspec)
+	end)
 end
 
 -- show the player the formspec they would see when right-clicking the node;
@@ -34,7 +36,9 @@ function travelnet.show_current_formspec(pos, meta, player_name)
 	local formspec = meta:get_string("formspec") ..
 		("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
 	-- show the formspec manually
-	minetest.show_formspec(player_name, travelnet_form_name, formspec)
+	minetest.after(0.1, function ()
+		minetest.show_formspec(player_name, travelnet_form_name, formspec)
+	end)
 end
 
 -- a player clicked on something in the formspec hse was manually shown
@@ -186,4 +190,3 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	-- show the formspec manually
 	minetest.show_formspec(player_name, travelnet_form_name, formspec)
 end
-

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -21,7 +21,7 @@ function travelnet.show_message(pos, player_name, title, message)
 			S("Exit"),
 			minetest.pos_to_string(pos)
 		)
-		minetest.after(0.1, minetest.show_formspec, player_name, travelnet_form_name, formspec)
+	minetest.after(0.1, minetest.show_formspec, player_name, travelnet_form_name, formspec)
 end
 
 -- show the player the formspec they would see when right-clicking the node;

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -216,4 +216,3 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 		end
 	end
 end
-

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -212,4 +212,5 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 		player:move_to(vector.add(target_pos, player_model_vec), false)
 		travelnet.rotate_player(target_pos, player)
 	end
+
 end


### PR DESCRIPTION
Fixes https://github.com/mt-mods/travelnet/issues/28

The opening of notification formspecs, as well as re-opening the old formspec when the "back" button is pressed, need to be delayed because they are not opening on the latest version of MT.

It seems that if a formspec is opened while the current formspec is closing (which happens for these formspecs because they are almost always triggered in `on_receive_fields`) then the new formspec never opens. This adds a small delay to make sure it is opened.

I also changed the message display from a textlist to a textarea because the textlist has unexpected behaviour when interacted with, the textarea should allow for extra-long messages to be displayed on multiple lines so is the best choice here.