### PR TITLE
Add paging mechanism

### DIFF
--- a/add_target.lua
+++ b/add_target.lua
@@ -58,7 +58,7 @@ function travelnet.add_target(station_name, network_name, pos, player_name, meta
 	end
 
 	-- we don't want too many stations in the same network because that would get confusing when displaying the targets
-	if station_count > travelnet.MAX_STATIONS_PER_NETWORK then
+	if not travelnet.paging_enabled and station_count > travelnet.MAX_STATIONS_PER_NETWORK then
 		travelnet.show_message(pos, player_name, S("Error"),
 				S("Network '@1', already contains the maximum number (@2) of allowed stations per network. " ..
 					"Please choose a different/new network name.", network_name, travelnet.MAX_STATIONS_PER_NETWORK))
@@ -103,4 +103,3 @@ function travelnet.add_target(station_name, network_name, pos, player_name, meta
 		travelnet.save_data()
 	end
 end
-

--- a/config.lua
+++ b/config.lua
@@ -1,5 +1,5 @@
 
-travelnet.paging_enabled = true
+travelnet.paging_enabled = false
 
 -- if paging is enabled this will be ignored
 travelnet.MAX_STATIONS_PER_NETWORK = 24

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,7 @@
 
+travelnet.paging_enabled = true
+
+-- if paging is enabled this will be ignored
 travelnet.MAX_STATIONS_PER_NETWORK = 24
 
 -- set this to true if you want a simulated beam effect

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -186,3 +186,4 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	-- show the formspec manually
 	minetest.show_formspec(player_name, travelnet_form_name, formspec)
 end
+

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -186,4 +186,3 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	-- show the formspec manually
 	minetest.show_formspec(player_name, travelnet_form_name, formspec)
 end
-

--- a/functions.lua
+++ b/functions.lua
@@ -381,7 +381,7 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 			return
 		end
 		-- does the new network have space at all?
-		if 1 + #network > travelnet.MAX_STATIONS_PER_NETWORK then
+		if not travelnet.paging_enabled and 1 + #network > travelnet.MAX_STATIONS_PER_NETWORK then
 			travelnet.show_message(pos, player_name, S("Error"),
 				S('Network "@1", already contains the maximum number (@2) of '
 					.. 'allowed stations per network. Please choose a '
@@ -426,7 +426,7 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 			return
 		end
 		-- does the new network have space at all?
-		if 1 + #network > travelnet.MAX_STATIONS_PER_NETWORK then
+		if not travelnet.paging_enabled and 1 + #network > travelnet.MAX_STATIONS_PER_NETWORK then
 			travelnet.show_message(pos, player_name, S("Error"),
 				S('Network "@1", already contains the maximum number (@2) of '
 					.. 'allowed stations per network. Please choose a '

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -37,6 +37,35 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 
 	local node = minetest.get_node(pos)
 
+	if travelnet.paging_enabled and fields.page_number and (fields.next_page or fields.prev_page or fields.last_page or fields.first_page) then
+		local page = 1
+		local network = travelnet.get_network(owner_name, station_network)
+		local station_count = 0
+		local network = travelnet.targets[owner_name][station_network]
+		for k in pairs(network) do
+			station_count = station_count+1
+		end
+		local page_size = 7*3
+		local pages = math.ceil(station_count/page_size)
+
+		if fields.last_page then
+			page = pages
+		else
+			local current_page = fields.page_number
+			if fields.next_page then
+				page = math.min(current_page+1, pages)
+			elseif fields.prev_page then
+				page = math.max(current_page-1, 1)
+			end
+		end
+
+		local formspec = travelnet.primary_formspec(pos, name, nil, page)
+		if formspec then
+			minetest.show_formspec(name, "travelnet:show", formspec)
+			return
+		end
+	end
+
 	-- the player wants to remove the station
 	if fields.station_dig or fields.station_edit then
 		local description = travelnet.node_description(pos)

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -185,13 +185,27 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 	if #stations < 10 then
 		x = 4
 	end
+	local paging = true
+	local column_size = paging and 7 or 8
+	local page_size = column_size*3
+	local page_number = 1
+	if paging then
+		for number,k in ipairs(stations) do
+			if k == station_name then
+				page_number = math.ceil(number/page_size)
+				break
+			end
+		end
+	end
 
-	for _,k in ipairs(stations) do
-
+	-- for number,k in ipairs(stations) do
+	for n=((page_number-1)*page_size)+1,(page_number*page_size) do
+		local k = stations[n]
+		if not k then break end
 		i = i+1
 
 		-- new column
-		if y == 8 then
+		if y == column_size then
 			x = x + 4
 			y = 0
 		end
@@ -227,6 +241,19 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 			S("move up"),
 			S("move down")
 		)
+	if paging then
+		formspec = formspec .. ([[
+			button[0,9.2;2,1;first_page;%s]
+			button[2,9.2;2,1;prev_page;%s]
+			button[8,9.2;2,1;next_page;%s]
+			button[10,9.2;2,1;last_page;%s]
+		]]):format(
+			minetest.formspec_escape(S("<<")),
+			minetest.formspec_escape(S("<")),
+			minetest.formspec_escape(S(">")),
+			minetest.formspec_escape(S(">>"))
+		)
+	end
 
 
 	meta:set_string("formspec", formspec)
@@ -240,4 +267,3 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 	-- show the player the updated formspec
 	travelnet.show_current_formspec(pos, meta, puncher_name)
 end
-

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -4,8 +4,9 @@ local function is_falsey_string(str)
 	return not str or str == ""
 end
 
--- called "on_punch" of travelnet and elevator
-function travelnet.update_formspec(pos, puncher_name, fields)
+
+function travelnet.primary_formspec(pos, puncher_name, fields, page_number)
+
 	local meta = minetest.get_meta(pos)
 
 	local node = minetest.get_node(pos)
@@ -185,15 +186,18 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 	if #stations < 10 then
 		x = 4
 	end
-	local paging = true
+	local paging = travelnet.paging_enabled and (#stations > 24)
 	local column_size = paging and 7 or 8
 	local page_size = column_size*3
-	local page_number = 1
-	if paging then
-		for number,k in ipairs(stations) do
-			if k == station_name then
-				page_number = math.ceil(number/page_size)
-				break
+	local pages = math.ceil(#stations/page_size)
+	if not page_number then
+		page_number = 1
+		if paging then
+			for number,k in ipairs(stations) do
+				if k == station_name then
+					page_number = math.ceil(number/page_size)
+					break
+				end
 			end
 		end
 	end
@@ -242,21 +246,41 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 			S("move down")
 		)
 	if paging then
-		formspec = formspec .. ([[
-			button[0,9.2;2,1;first_page;%s]
-			button[2,9.2;2,1;prev_page;%s]
-			button[8,9.2;2,1;next_page;%s]
-			button[10,9.2;2,1;last_page;%s]
-		]]):format(
-			minetest.formspec_escape(S("<<")),
-			minetest.formspec_escape(S("<")),
-			minetest.formspec_escape(S(">")),
-			minetest.formspec_escape(S(">>"))
-		)
+		if page_number > 2 then
+			formspec = formspec .. ("button[0,9.2;2,1;first_page;%s]"):format(minetest.formspec_escape(S("<<")))
+		end
+		if page_number > 1 then
+			formspec = formspec .. ("button[2,9.2;2,1;prev_page;%s]"):format(minetest.formspec_escape(S("<")))
+		end
+		formspec = formspec
+			.. ("label[5,9.4;%s]"):format(minetest.formspec_escape(S("Page @1/@2", page_number, pages)))
+			.. ("field[20,20;0.1,0.1;page_number;Page;%i]"):format(page_number)
+			.. ("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
+		if page_number < pages then
+			formspec = formspec .. ("button[8,9.2;2,1;next_page;%s]"):format(minetest.formspec_escape(S(">")))
+		end
+		if page_number < pages-1 then
+			formspec = formspec .. ("button[10,9.2;2,1;last_page;%s]"):format(minetest.formspec_escape(S(">>")))
+		end
 	end
 
+	return formspec
+end
+
+-- called "on_punch" of travelnet and elevator
+function travelnet.update_formspec(pos, puncher_name, fields)
+
+	local formspec = travelnet.primary_formspec(pos, puncher_name, fields)
+
+	if not formspec then return end
+
+	local meta = minetest.get_meta(pos)
 
 	meta:set_string("formspec", formspec)
+
+	local owner_name      = meta:get_string("owner")
+	local station_name    = meta:get_string("station_name")
+	local station_network = meta:get_string("station_network")
 
 	meta:set_string("infotext",
 			S("Station '@1'" .. " " ..


### PR DESCRIPTION
Fixes https://github.com/mt-mods/travelnet/issues/29

Added a new config option `travelnet.paging_enabled`, which lifts the station count limit.

There are also new buttons on the form that can be used to go back & forth, as well as to the start and end, the page number is displayed in the centre.

The form will always display the page the station is on by default, unless the page is changed using the controls.