### PR TITLE
Check that a node is in fact a travelnet or elevator before parsing input data

### DIFF
--- a/formspecs.lua
+++ b/formspecs.lua
@@ -46,6 +46,9 @@ function travelnet.form_input_handler(player, formname, fields)
 		if not pos then
 			return
 		end
+		if not travelnet.is_travelnet_or_elevator(pos) then
+			return
+		end
 
 		-- back button leads back to the main menu
 		if fields.back and fields.back ~= "" then
@@ -186,4 +189,3 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	-- show the formspec manually
 	minetest.show_formspec(player_name, travelnet_form_name, formspec)
 end
-

--- a/functions.lua
+++ b/functions.lua
@@ -83,7 +83,7 @@ end
 function travelnet.is_travelnet_or_elevator(pos)
 	local node = minetest.get_node(pos)
 	local node_def = minetest.registered_nodes[node.name]
-	return node_def.groups.travelnet or node_def.groups.elevator
+	return node_def and node_def.groups and (node_def.groups.travelnet or node_def.groups.elevator)
 end
 
 function travelnet.door_is_open(node, opposite_direction)

--- a/functions.lua
+++ b/functions.lua
@@ -80,6 +80,12 @@ function travelnet.is_elevator(node_name)
 	return node_name == "travelnet:elevator"
 end
 
+function travelnet.is_travelnet_or_elevator(pos)
+	local node = minetest.get_node(pos)
+	local node_def = minetest.registered_nodes[node.name]
+	return node_def.groups.travelnet or node_def.groups.elevator
+end
+
 function travelnet.door_is_open(node, opposite_direction)
 	return string.sub(node.name, -5) == "_open"
 		-- handle doors that change their facedir

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -193,9 +193,7 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 	minetest.load_area(target_pos)
 
 	-- check if the box has at the other end has been removed.
-	local target_node = minetest.get_node(target_pos)
-	local target_node_def = minetest.registered_nodes[target_node.name]
-	local has_travelnet_group = target_node_def.groups.travelnet or target_node_def.groups.elevator
+	local has_travelnet_group = travelnet.is_travelnet_or_elevator(target_pos)
 
 	if not has_travelnet_group then
 		-- provide information necessary to identify the removed box


### PR DESCRIPTION
Created a new `travelnet.is_travelnet_or_elevator` method for checking if the node at a position is in fact dealt with by this mod and used this to validate the `pos2str` value.

This may be made redundant by the resolution to other issues (#33), but ATM it's a crashing bug, and the new API method is probably nice to have anyways.

Logic copied from the destination check.