### PR TITLE
use the settings api with fallback defaults

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -5,7 +5,7 @@ travelnet.MAX_STATIONS_PER_NETWORK = tonumber(minetest.settings:get("travelnet.M
 -- set this to true if you want a simulated beam effect
 travelnet.travelnet_effect_enabled = minetest.settings:get_bool("travelnet.travelnet_effect_enabled", false)
 -- set this to true if you want a sound to be played when the travelnet is used
-travelnet.travelnet_sound_enabled  = minetest.settings:get_bool("travelnet.travelnet_sound_enabled", false)
+travelnet.travelnet_sound_enabled  = minetest.settings:get_bool("travelnet.travelnet_sound_enabled", true)
 
 -- if you set this to false, travelnets cannot be created
 -- (this may be useful if you want nothing but the elevators on your server)
@@ -100,5 +100,3 @@ end
 travelnet.allow_travel = function()
 	return minetest.settings:get_bool("travelnet.allow_travel", true)
 end
-
-travelnet.travelnet_sound_enabled = minetest.settings:get_bool("travelnet.travelnet_sound_enabled", true)

--- a/config.lua
+++ b/config.lua
@@ -1,23 +1,23 @@
 
 -- set this to 0 if you want no limit
-travelnet.MAX_STATIONS_PER_NETWORK = 24
+travelnet.MAX_STATIONS_PER_NETWORK = tonumber(minetest.settings:get("travelnet.MAX_STATIONS_PER_NETWORK")) or 24
 
 -- set this to true if you want a simulated beam effect
-travelnet.travelnet_effect_enabled = false
+travelnet.travelnet_effect_enabled = minetest.settings:get_bool("travelnet.travelnet_effect_enabled", false)
 -- set this to true if you want a sound to be played when the travelnet is used
-travelnet.travelnet_sound_enabled  = false
+travelnet.travelnet_sound_enabled  = minetest.settings:get_bool("travelnet.travelnet_sound_enabled", false)
 
 -- if you set this to false, travelnets cannot be created
 -- (this may be useful if you want nothing but the elevators on your server)
-travelnet.travelnet_enabled        = true
+travelnet.travelnet_enabled        = minetest.settings:get_bool("travelnet.travelnet_enabled", true)
 -- if you set travelnet.elevator_enabled to false, you will not be able to
 -- craft, place or use elevators
-travelnet.elevator_enabled         = true
+travelnet.elevator_enabled         = minetest.settings:get_bool("travelnet.elevator_enabled", true)
 -- if you set this to false, doors will be disabled
-travelnet.doors_enabled            = true
+travelnet.doors_enabled            = minetest.settings:get_bool("travelnet.doors_enabled", true)
 
 -- starts an abm which re-adds travelnet stations to networks in case the savefile got lost
-travelnet.abm_enabled              = false
+travelnet.abm_enabled              = minetest.settings:get_bool("travelnet.abm_enabled", false)
 
 -- change these if you want other receipes for travelnet or elevator
 travelnet.travelnet_recipe = {
@@ -77,7 +77,7 @@ end
 -- can still add stations to that network
 -- params: player_name, owner_name, network_name
 travelnet.allow_attach = function()
-	return false
+	return minetest.settings:get_bool("travelnet.allow_attach", false)
 end
 
 
@@ -86,7 +86,7 @@ end
 -- has the travelnet_remove priv
 -- params: player_name, owner_name, network_name, pos
 travelnet.allow_dig = function()
-	return false
+	return minetest.settings:get_bool("travelnet.allow_dig", false)
 end
 
 
@@ -98,7 +98,7 @@ end
 -- usage of stations to players in the same fraction on PvP servers
 -- params: player_name, owner_name, network_name, station_name_start, station_name_target
 travelnet.allow_travel = function()
-	return true
+	return minetest.settings:get_bool("travelnet.allow_travel", true)
 end
 
-travelnet.travelnet_sound_enabled = true
+travelnet.travelnet_sound_enabled = minetest.settings:get_bool("travelnet.travelnet_sound_enabled", true)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,11 @@
+
+travelnet.MAX_STATIONS_PER_NETWORK (max stations on a network, 0 for unlimited) int 24
+travelnet.travelnet_effect_enabled (simulated beam effect) bool false
+travelnet.travelnet_sound_enabled (sound played on travelent use) bool true
+travelnet.travelnet_enabled (enable/disable travelnets) bool true
+travelnet.elevator_enabled (enable/disable elevators) bool true
+travelnet.doors_enabled (enable/disable travelnet doors) bool true
+travelnet.abm_enabled (abm solution for load travelnet network back from meta) bool false
+travelnet.allow_attach (allow anyone to add a travelnet to any network) bool false
+travelnet.allow_dig (allow anyone to remove travelnets from any network) bool false
+travelnet.allow_travel (allow players to use other networks) bool true


### PR DESCRIPTION
use the minetest settings api while keeping the values in the travelnet global table so that legacy mods can keep overriding them. This is current still in draft as a settingtypes.txt file needs to be added. closes https://github.com/mt-mods/travelnet/issues/38