### PR TITLE
Remove the usage of pos2str using context var

### DIFF
--- a/formspecs.lua
+++ b/formspecs.lua
@@ -207,7 +207,7 @@ end
 function travelnet.page_formspec(pos, player_name, page)
 	local formspec = travelnet.primary_formspec(pos, player_name, nil, page)
 	if formspec then
-		minetest.show_formspec(player_name, travelnet_form_name, formspec)
+		travelnet.set_formspec(player_name, formspec)
 		return
 	end
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -2,6 +2,8 @@ local S = minetest.get_translator("travelnet")
 
 local travelnet_form_name = "travelnet:show"
 
+local player_formspec_data = travelnet.player_formspec_data
+
 -- minetest.chat_send_player is sometimes not so well visible
 function travelnet.show_message(pos, player_name, title, message)
 	if not pos or not player_name or not message then
@@ -13,7 +15,6 @@ function travelnet.show_message(pos, player_name, title, message)
 			textarea[0.5,0.5;7,1.5;;%s;]
 			button[3.5,2.5;1.0,0.5;back;%s]
 			button[6.8,2.5;1.0,0.5;station_exit;%s]
-			field[20,20;0.1,0.1;pos2str;Pos;%s]
 		]]):format(
 			minetest.formspec_escape(title or S("Error")),
 			minetest.formspec_escape(message or "- nothing -"),
@@ -31,8 +32,7 @@ function travelnet.show_current_formspec(pos, meta, player_name)
 		return
 	end
 	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string("formspec") ..
-		("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
+	local formspec = meta:get_string("formspec")
 	-- show the formspec manually
 	travelnet.set_formspec(player_name, formspec)
 end
@@ -41,20 +41,18 @@ end
 -- (back from help page, moved travelnet up or down etc.)
 function travelnet.form_input_handler(player, formname, fields)
 	if formname ~= travelnet_form_name then return end
-	if fields and fields.pos2str then
-		local pos = minetest.string_to_pos(fields.pos2str)
-		if not pos then return end
-		local node = minetest.get_node(pos)
-		if minetest.get_item_group(node.name, "travelnet") == 0 and minetest.get_item_group(node.name, "elevator") == 0 then
-			return
-		end
-
+	if fields then
 		-- back button leads back to the main menu
 		if fields.back and fields.back ~= "" then
+			local player_name = player:get_player_name()
+			local pos = player_formspec_data[player_name] and player_formspec_data[player_name].pos
+			if not pos then
+				return
+			end
 			return travelnet.show_current_formspec(pos,
-					minetest.get_meta(pos), player:get_player_name())
+					minetest.get_meta(pos), player_name)
 		end
-		return travelnet.on_receive_fields(pos, formname, fields, player)
+		return travelnet.on_receive_fields(nil, formname, fields, player)
 	end
 end
 
@@ -136,7 +134,6 @@ function travelnet.edit_formspec(pos, meta, player_name)
 		label[0.3,4.7;%s]
 		button[3.8,5.3;1.7,0.7;station_set;%s]
 		button[6.3,5.3;1.7,0.7;station_exit;%s]
-		field[20,20;0.1,0.1;pos2str;Pos;%s]
 	]]):format(
 		S("Configure this travelnet station"),
 		S("Remove station"),
@@ -174,7 +171,6 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 		field[0.3,1.2;9,0.9;station_name;%s:;%s]
 		button[3.8,5.3;1.7,0.7;station_set;%s]
 		button[6.3,5.3;1.7,0.7;station_exit;%s]
-		field[20,20;0.1,0.1;pos2str;Pos;%s]
 	]]):format(
 		S("Configure this elevator station"),
 		S("Remove station"),
@@ -189,7 +185,6 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	travelnet.set_formspec(player_name, formspec)
 end
 
-local player_formspec_data = travelnet.player_formspec_data
 function travelnet.set_formspec(player_name, formspec)
 	if player_formspec_data[player_name] and player_formspec_data[player_name].wait_mode then
 		player_formspec_data[player_name].formspec = formspec
@@ -206,6 +201,7 @@ function travelnet.show_formspec(player_name)
 		minetest.show_formspec(player_name, "", "")
 	end
 	player_formspec_data[player_name].formspec = nil
+	return formspec
 end
 
 function travelnet.page_formspec(pos, player_name, page)

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -1,6 +1,8 @@
 local S = minetest.get_translator("travelnet")
 
-local function on_receive_fields_internal(pos, _, fields, player)
+local player_formspec_data = travelnet.player_formspec_data
+
+local function on_receive_fields_internal(pos, fields, player)
 	if not pos then
 		return
 	end
@@ -244,11 +246,22 @@ local function on_receive_fields_internal(pos, _, fields, player)
 
 end
 
-local player_formspec_data = travelnet.player_formspec_data
 function travelnet.on_receive_fields(pos, _, fields, player)
 	local name = player:get_player_name()
-	player_formspec_data[name] = {wait_mode=true}
-	on_receive_fields_internal(pos, _, fields, player)
-	travelnet.show_formspec(name)
-	player_formspec_data[name] = nil
+	player_formspec_data[name] = player_formspec_data[name] or {}
+	if pos then
+		player_formspec_data[name].pos = pos
+	else
+		pos = player_formspec_data[name].pos
+	end
+
+	player_formspec_data[name].wait_mode = true
+	on_receive_fields_internal(pos, fields, player)
+
+	local closed = not travelnet.show_formspec(name)
+	if fields.quit or closed then
+		player_formspec_data[name] = nil
+	else
+		player_formspec_data[name].wait_mode = nil
+	end
 end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -1,5 +1,7 @@
 local S = minetest.get_translator("travelnet")
 
+local player_formspec_data = travelnet.player_formspec_data
+
 local function is_falsey_string(str)
 	return not str or str == ""
 end
@@ -290,6 +292,9 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 				"on travelnet '@2' (owned by @3)" .. " " ..
 				"ready for usage. Right-click to travel, punch to update.",
 				tostring(station_name), tostring(station_network), tostring(owner_name)))
+
+	player_formspec_data[puncher_name] = player_formspec_data[puncher_name] or {}
+	player_formspec_data[puncher_name].pos = pos
 
 	-- show the player the updated formspec
 	travelnet.show_current_formspec(pos, meta, puncher_name)

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -259,7 +259,6 @@ function travelnet.primary_formspec(pos, puncher_name, fields, page_number)
 		formspec = formspec
 			.. ("label[5,9.4;%s]"):format(minetest.formspec_escape(S("Page @1/@2", page_number, pages)))
 			.. ("field[20,20;0.1,0.1;page_number;Page;%i]"):format(page_number)
-			.. ("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
 		if page_number < pages then
 			formspec = formspec .. ("button[8,9.2;2,1;next_page;%s]"):format(minetest.formspec_escape(S(">")))
 		end


### PR DESCRIPTION
Fixes https://github.com/mt-mods/travelnet/issues/33

Uses the per-player context introduced in https://github.com/mt-mods/travelnet/pull/35 to store the position of the node being interacted with, replacing the need for `pos2str`