### PR TITLE
Generate formspecs on interact, not on update

### DIFF
--- a/add_target.lua
+++ b/add_target.lua
@@ -84,20 +84,11 @@ function travelnet.add_target(station_name, network_name, pos, player_name, meta
 		meta:set_string("owner",           owner_name)
 		meta:set_int   ("timestamp",       creation_timestamp)
 
-		meta:set_string("formspec",
-				([[
-					size[12,10]
-					field[0.3,0.6;6,0.7;station_name;%s;%s]
-					field[0.3,3.6;6,0.7;station_network;%s;%s]
-				]]):format(
-					S("Station:"),
-					minetest.formspec_escape(station_name),
-					S("Network:"),
-					minetest.formspec_escape(network_name)
-				))
-
-		-- display a list of all stations that can be reached from here
-		travelnet.update_formspec(pos, player_name, nil)
+		meta:set_string("infotext",
+				S("Station '@1'" .. " " ..
+					"on travelnet '@2' (owned by @3)" .. " " ..
+					"ready for usage.",
+					tostring(station_name), tostring(network_name), tostring(owner_name)))
 
 		-- save the updated network data in a savefile over server restart
 		travelnet.save_data()

--- a/elevator.lua
+++ b/elevator.lua
@@ -3,6 +3,8 @@
 -- Author: Sokomine
 local S = minetest.get_translator("travelnet")
 
+local player_formspec_data = travelnet.player_formspec_data
+
 function travelnet.show_nearest_elevator(pos, owner_name, param2)
 	if not pos or not pos.x or not pos.z or not owner_name then
 		return
@@ -70,6 +72,26 @@ function travelnet.show_nearest_elevator(pos, owner_name, param2)
 end
 
 
+local function on_interact(pos, _, player)
+	local meta = minetest.get_meta(pos)
+	local station_network = meta:get_string("station_network")
+	local player_name = player:get_player_name()
+
+	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
+	player_formspec_data[player_name].pos = pos
+
+	if travelnet.is_falsey_string(station_network) then
+		-- request initial data
+		travelnet.set_formspec(player:get_player_name(), ([[
+			size[12,10]
+			field[0.3,5.6;6,0.7;station_name;%s;]
+			button[6.3,6.2;1.7,0.7;station_set;%s]
+		]]):format(S("Name of this station:"), S("Store")))
+	else
+		travelnet.page_formspec(pos, player_name)
+	end
+end
+
 minetest.register_node("travelnet:elevator", {
 	description = S("Elevator"),
 	drawtype = "mesh",
@@ -113,21 +135,12 @@ minetest.register_node("travelnet:elevator", {
 		meta:set_string("station_network","")
 		meta:set_string("owner",          placer:get_player_name())
 
-		-- request initial data
-		meta:set_string("formspec", ([[
-			size[12,10]
-			field[0.3,5.6;6,0.7;station_name;%s;]
-			button[6.3,6.2;1.7,0.7;station_set;%s]
-		]]):format(S("Name of this station:"), S("Store")))
-
 		minetest.set_node(vector.add(pos, { x=0, y=1, z=0 }), { name="travelnet:hidden_top" })
 		travelnet.show_nearest_elevator(pos, placer:get_player_name(), minetest.dir_to_facedir(placer:get_look_dir()))
 	end,
 
-	on_receive_fields = travelnet.on_receive_fields,
-	on_punch = function(pos, _, puncher)
-		travelnet.update_formspec(pos, puncher:get_player_name())
-	end,
+	on_rightclick = on_interact,
+	on_punch = on_interact,
 
 	can_dig = function(pos, player)
 		return travelnet.can_dig(pos, player, "elevator")

--- a/elevator.lua
+++ b/elevator.lua
@@ -76,6 +76,10 @@ local function on_interact(pos, _, player)
 	local meta = minetest.get_meta(pos)
 	local station_network = meta:get_string("station_network")
 	local player_name = player:get_player_name()
+	local legacy_formspec = meta:get_string("formspec")
+	if not travelnet.is_falsey_string(legacy_formspec) then
+		meta:set_string("formspec", "")
+	end
 
 	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
 	player_formspec_data[player_name].pos = pos

--- a/elevator.lua
+++ b/elevator.lua
@@ -88,7 +88,7 @@ local function on_interact(pos, _, player)
 			button[6.3,6.2;1.7,0.7;station_set;%s]
 		]]):format(S("Name of this station:"), S("Store")))
 	else
-		travelnet.page_formspec(pos, player_name)
+		travelnet.show_current_formspec(pos, nil, player_name)
 	end
 end
 

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -207,7 +207,7 @@ end
 function travelnet.page_formspec(pos, player_name, page)
 	local formspec = travelnet.primary_formspec(pos, player_name, nil, page)
 	if formspec then
-		minetest.show_formspec(player_name, travelnet_form_name, formspec)
+		travelnet.set_formspec(player_name, formspec)
 		return
 	end
 end

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -27,7 +27,7 @@ end
 
 -- show the player the formspec they would see when right-clicking the node;
 -- needs to be simulated this way as calling on_rightclick would not do
-function travelnet.show_current_formspec(pos, meta, player_name)
+function travelnet.show_current_formspec(pos, _, player_name)
 	travelnet.page_formspec(pos, player_name)
 end
 
@@ -43,8 +43,7 @@ function travelnet.form_input_handler(player, formname, fields)
 			if not pos then
 				return
 			end
-			return travelnet.show_current_formspec(pos,
-					minetest.get_meta(pos), player_name)
+			return travelnet.show_current_formspec(pos, nil, player_name)
 		end
 		return travelnet.on_receive_fields(nil, formname, fields, player)
 	end
@@ -56,8 +55,10 @@ end
 minetest.register_on_player_receive_fields(travelnet.form_input_handler)
 
 
-function travelnet.reset_formspec(meta)
-	minetest.log("warning", "[travelnet] the travelnet.reset_formspec method is deprecated. Run meta:set_string('station_network', '') to reset the travelnet.")
+function travelnet.reset_formspec()
+	minetest.log("warning",
+		"[travelnet] the travelnet.reset_formspec method is deprecated. "..
+		"Run meta:set_string('station_network', '') to reset the travelnet.")
 end
 
 

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -28,13 +28,7 @@ end
 -- show the player the formspec they would see when right-clicking the node;
 -- needs to be simulated this way as calling on_rightclick would not do
 function travelnet.show_current_formspec(pos, meta, player_name)
-	if not pos or not meta or not player_name then
-		return
-	end
-	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string("formspec")
-	-- show the formspec manually
-	travelnet.set_formspec(player_name, formspec)
+	travelnet.page_formspec(pos, player_name)
 end
 
 -- a player clicked on something in the formspec hse was manually shown
@@ -63,45 +57,7 @@ minetest.register_on_player_receive_fields(travelnet.form_input_handler)
 
 
 function travelnet.reset_formspec(meta)
-	if not meta then return end
-
-	meta:set_string("infotext",       S("Travelnet-box (unconfigured)"))
-	meta:set_string("station_name",   "")
-	meta:set_string("station_network","")
-	meta:set_string("owner",          "")
-
-	-- some players seem to be confused with entering network names at first; provide them
-	-- with a default name
-	local default_network = "net1"
-
-	-- request initinal data
-	meta:set_string("formspec",
-			([[
-				size[10,6.0]
-				label[2.0,0.0;--> %s <--]
-				button[8.0,0.0;2.2,0.7;station_dig;%s]
-				field[0.3,1.2;9,0.9;station_name;%s:;]
-				label[0.3,1.5;%s]
-				field[0.3,2.8;9,0.9;station_network;%s;%s]
-				label[0.3,3.1;%s]
-				field[0.3,4.4;9,0.9;owner;%s;]
-				label[0.3,4.7;%s]
-				button[3.8,5.3;1.7,0.7;station_set;%s]
-				button[6.3,5.3;1.7,0.7;station_exit;%s]
-			]]):format(
-				S("Configure this travelnet station"),
-				S("Remove station"),
-				S("Name of this station"),
-				S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"..."),
-				S("Assign to Network:"),
-				default_network,
-				S("You can have more than one network. If unsure, use \"@1\".", default_network),
-				S("Owned by:"),
-				S("Unless you know what you are doing, leave this empty."),
-				S("Save"),
-				S("Exit")
-			)
-	)
+	minetest.log("warning", "[travelnet] the travelnet.reset_formspec method is deprecated. Run meta:set_string('station_network', '') to reset the travelnet.")
 end
 
 

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -2,6 +2,8 @@ local S = minetest.get_translator("travelnet")
 
 local travelnet_form_name = "travelnet:show"
 
+local player_formspec_data = travelnet.player_formspec_data
+
 -- minetest.chat_send_player is sometimes not so well visible
 function travelnet.show_message(pos, player_name, title, message)
 	if not pos or not player_name or not message then
@@ -13,7 +15,6 @@ function travelnet.show_message(pos, player_name, title, message)
 			textarea[0.5,0.5;7,1.5;;%s;]
 			button[3.5,2.5;1.0,0.5;back;%s]
 			button[6.8,2.5;1.0,0.5;station_exit;%s]
-			field[20,20;0.1,0.1;pos2str;Pos;%s]
 		]]):format(
 			minetest.formspec_escape(title or S("Error")),
 			minetest.formspec_escape(message or "- nothing -"),
@@ -31,8 +32,7 @@ function travelnet.show_current_formspec(pos, meta, player_name)
 		return
 	end
 	-- we need to supply the position of the travelnet box
-	local formspec = meta:get_string("formspec") ..
-		("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
+	local formspec = meta:get_string("formspec")
 	-- show the formspec manually
 	travelnet.set_formspec(player_name, formspec)
 end
@@ -41,20 +41,18 @@ end
 -- (back from help page, moved travelnet up or down etc.)
 function travelnet.form_input_handler(player, formname, fields)
 	if formname ~= travelnet_form_name then return end
-	if fields and fields.pos2str then
-		local pos = minetest.string_to_pos(fields.pos2str)
-		if not pos then return end
-		local node = minetest.get_node(pos)
-		if minetest.get_item_group(node.name, "travelnet") == 0 and minetest.get_item_group(node.name, "elevator") == 0 then
-			return
-		end
-
+	if fields then
 		-- back button leads back to the main menu
 		if fields.back and fields.back ~= "" then
+			local player_name = player:get_player_name()
+			local pos = player_formspec_data[player_name] and player_formspec_data[player_name].pos
+			if not pos then
+				return
+			end
 			return travelnet.show_current_formspec(pos,
-					minetest.get_meta(pos), player:get_player_name())
+					minetest.get_meta(pos), player_name)
 		end
-		return travelnet.on_receive_fields(pos, formname, fields, player)
+		return travelnet.on_receive_fields(nil, formname, fields, player)
 	end
 end
 
@@ -136,7 +134,6 @@ function travelnet.edit_formspec(pos, meta, player_name)
 		label[0.3,4.7;%s]
 		button[3.8,5.3;1.7,0.7;station_set;%s]
 		button[6.3,5.3;1.7,0.7;station_exit;%s]
-		field[20,20;0.1,0.1;pos2str;Pos;%s]
 	]]):format(
 		S("Configure this travelnet station"),
 		S("Remove station"),
@@ -174,7 +171,6 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 		field[0.3,1.2;9,0.9;station_name;%s:;%s]
 		button[3.8,5.3;1.7,0.7;station_set;%s]
 		button[6.3,5.3;1.7,0.7;station_exit;%s]
-		field[20,20;0.1,0.1;pos2str;Pos;%s]
 	]]):format(
 		S("Configure this elevator station"),
 		S("Remove station"),
@@ -189,7 +185,6 @@ function travelnet.edit_formspec_elevator(pos, meta, player_name)
 	travelnet.set_formspec(player_name, formspec)
 end
 
-local player_formspec_data = travelnet.player_formspec_data
 function travelnet.set_formspec(player_name, formspec)
 	if player_formspec_data[player_name] and player_formspec_data[player_name].wait_mode then
 		player_formspec_data[player_name].formspec = formspec
@@ -206,6 +201,7 @@ function travelnet.show_formspec(player_name)
 		minetest.show_formspec(player_name, "", "")
 	end
 	player_formspec_data[player_name].formspec = nil
+	return formspec
 end
 
 function travelnet.page_formspec(pos, player_name, page)

--- a/functions.lua
+++ b/functions.lua
@@ -687,7 +687,7 @@ function travelnet.change_order(pos, player_name, fields)
 
 			-- store the changed order
 			travelnet.save_data()
-			travelnet.page_formspec(pos, player_name)
+			travelnet.show_current_formspec(pos, nil, player_name)
 		end
 	end
 end

--- a/functions.lua
+++ b/functions.lua
@@ -413,6 +413,12 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 				station_name, fields.station_name,
 				station_network, fields.station_network,
 				owner_name, fields.owner))
+
+		meta:set_string("infotext",
+				S("Station '@1'" .. " " ..
+					"on travelnet '@2' (owned by @3)" .. " " ..
+					"ready for usage.",
+					tostring(fields.station_name), tostring(fields.station_network), tostring(fields.owner)))
 	elseif station_network ~= fields.station_network then
 		-- same owner but different network -> remove station from old network
 		-- but only if there is space on the new network and no other station with that name
@@ -455,6 +461,12 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 				.. 'from network "@3" to network "@4".',
 				station_name, fields.station_name,
 				station_network, fields.station_network))
+
+		meta:set_string("infotext",
+				S("Station '@1'" .. " " ..
+					"on travelnet '@2' (owned by @3)" .. " " ..
+					"ready for usage.",
+					tostring(fields.station_name), tostring(fields.station_network), tostring(owner_name)))
 	else
 		-- only name changed -> change name but keep timestamp to preserve order
 		network = travelnet.get_network(owner_name, station_network)
@@ -479,22 +491,13 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 		minetest.chat_send_player(player_name,
 			S('Station "@1" has been renamed to "@2" on network "@3".',
 				station_name, fields.station_name, station_network))
+
+		meta:set_string("infotext",
+				S("Station '@1'" .. " " ..
+					"on travelnet '@2' (owned by @3)" .. " " ..
+					"ready for usage.",
+					tostring(fields.station_name), tostring(station_network), tostring(owner_name)))
 	end
-
-	meta:set_string("formspec",
-		([[
-			size[12,10]
-			field[0.3,0.6;6,0.7;station_name;%s;%s]
-			field[0.3,3.6;6,0.7;station_network;%s;%s]
-		]]):format(
-			S("Station:"),
-			minetest.formspec_escape(fields.station_name),
-			S("Network:"),
-			minetest.formspec_escape(fields.network_name)
-	))
-
-	-- update the formspec of this station
-	travelnet.update_formspec(pos, player_name, nil)
 
 	-- save the updated network data in a savefile over server restart
 	travelnet.save_data()
@@ -567,20 +570,11 @@ function travelnet.edit_elevator(pos, fields, meta, player_name)
 		S('Station "@1" has been renamed to "@2" on network "@3".',
 			station_name, fields.station_name, station_network))
 
-	meta:set_string("formspec",
-		([[
-			size[12,10]
-			field[0.3,0.6;6,0.7;station_name;%s;%s]
-			field[0.3,3.6;6,0.7;station_network;%s;%s]
-		]]):format(
-			S("Station:"),
-			minetest.formspec_escape(fields.station_name),
-			S("Network:"),
-			minetest.formspec_escape(fields.network_name)
-	))
-
-	-- update the formspec of this station
-	travelnet.update_formspec(pos, player_name, nil)
+	meta:set_string("infotext",
+			S("Station '@1'" .. " " ..
+				"on travelnet '@2' (owned by @3)" .. " " ..
+				"ready for usage.",
+				tostring(fields.station_name), tostring(station_network), tostring(owner_name)))
 
 	-- save the updated network data in a savefile over server restart
 	travelnet.save_data()
@@ -590,4 +584,110 @@ end
 travelnet.can_dig = function()
 	-- forbid digging of the travelnet
 	return false
+end
+
+function travelnet.change_order(pos, player_name, fields)
+	local node = minetest.get_node(pos)
+	local is_elevator = travelnet.is_elevator(node.name)
+
+	local meta = minetest.get_meta(pos)
+	local owner_name      = meta:get_string("owner")
+	local station_network = meta:get_string("station_network")
+	local station_name    = meta:get_string("station_name")
+
+	-- does the player want to move this station one position up in the list?
+	-- only the owner and players with the travelnet_attach priv can change the order of the list
+	-- Note: With elevators, only the "G"(round) marking is actually moved
+	if	    fields and (fields.move_up or fields.move_down)
+		and not travelnet.is_falsey_string(owner_name)
+		and (
+			   (owner_name == player_name)
+			or (minetest.check_player_privs(player_name, { travelnet_attach=true }))
+		)
+	then
+
+		local stations = {}
+		local network = travelnet.targets[owner_name][station_network]
+
+		for k in pairs(network) do
+			table.insert(stations, k)
+		end
+
+		local ground_level = 1
+		if is_elevator then
+			table.sort(stations, function(a, b)
+				return network[a].pos.y > network[b].pos.y
+			end)
+
+			-- find ground level
+			local vgl_timestamp = 999999999999
+			for index,k in ipairs(stations) do
+				local station = network[k]
+				if not station.timestamp then
+					station.timestamp = os.time()
+				end
+				if station.timestamp < vgl_timestamp then
+					vgl_timestamp = station.timestamp
+					ground_level  = index
+				end
+			end
+
+			for index,k in ipairs(stations) do
+				local station = network[k]
+				if index == ground_level then
+					station.nr = "G"
+				else
+					station.nr = tostring(ground_level - index)
+				end
+			end
+		else
+			-- sort the table according to the timestamp (=time the station was configured)
+			table.sort(stations, function(a, b)
+				return network[a].timestamp < network[b].timestamp
+			end)
+		end
+
+		local current_pos = -1
+		for index, k in ipairs(stations) do
+			if k == station_name then
+				current_pos = index
+				break
+			end
+		end
+
+		local swap_with_pos
+		if fields.move_up then
+			swap_with_pos = current_pos-1
+		else
+			swap_with_pos = current_pos+1
+		end
+
+		-- handle errors
+		if swap_with_pos < 1 then
+			travelnet.show_message(pos, player_name, "Info", S("This station is already the first one on the list."))
+			return
+		elseif swap_with_pos > #stations then
+			travelnet.show_message(pos, player_name, "Info", S("This station is already the last one on the list."))
+			return
+		else
+			local current_station = stations[current_pos]
+			local swap_with_station = stations[swap_with_pos]
+
+			-- swap the actual data by which the stations are sorted
+			local old_timestamp = network[swap_with_station].timestamp
+			network[swap_with_station].timestamp = network[current_station].timestamp
+			network[current_station].timestamp = old_timestamp
+
+			-- for elevators, only the "G"(round) marking is moved; no point in swapping stations
+			if not is_elevator then
+				-- actually swap the stations
+				stations[swap_with_pos] = current_station
+				stations[current_pos]   = swap_with_station
+			end
+
+			-- store the changed order
+			travelnet.save_data()
+			travelnet.page_formspec(pos, player_name)
+		end
+	end
 end

--- a/functions.lua
+++ b/functions.lua
@@ -352,6 +352,7 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 	local station_network = meta:get_string("station_network")
 	local station_name	= meta:get_string("station_name")
 	local description, node_name  = travelnet.node_description(pos)
+	local new_owner_name, new_station_network, new_station_name
 
 	if not description then
 		minetest.chat_send_player(player_name, "Error: Unknown node.")
@@ -461,11 +462,9 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 				station_network, fields.station_network,
 				owner_name, fields.owner))
 
-		meta:set_string("infotext",
-				S("Station '@1'" .. " " ..
-					"on travelnet '@2' (owned by @3)" .. " " ..
-					"ready for usage.",
-					tostring(fields.station_name), tostring(fields.station_network), tostring(fields.owner)))
+		new_owner_name = fields.owner
+		new_station_network = fields.station_network
+		new_station_name = fields.station_name
 	elseif station_network ~= fields.station_network then
 		-- same owner but different network -> remove station from old network
 		-- but only if there is space on the new network and no other station with that name
@@ -509,11 +508,8 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 				station_name, fields.station_name,
 				station_network, fields.station_network))
 
-		meta:set_string("infotext",
-				S("Station '@1'" .. " " ..
-					"on travelnet '@2' (owned by @3)" .. " " ..
-					"ready for usage.",
-					tostring(fields.station_name), tostring(fields.station_network), tostring(owner_name)))
+		new_station_network = fields.station_network
+		new_station_name = fields.station_name
 	else
 		-- only name changed -> change name but keep timestamp to preserve order
 		network = travelnet.get_network(owner_name, station_network)
@@ -539,12 +535,17 @@ function travelnet.edit_box(pos, fields, meta, player_name)
 			S('Station "@1" has been renamed to "@2" on network "@3".',
 				station_name, fields.station_name, station_network))
 
-		meta:set_string("infotext",
-				S("Station '@1'" .. " " ..
-					"on travelnet '@2' (owned by @3)" .. " " ..
-					"ready for usage.",
-					tostring(fields.station_name), tostring(station_network), tostring(owner_name)))
+		new_station_name = fields.station_name
 	end
+
+	meta:set_string("infotext",
+			S("Station '@1'" .. " " ..
+				"on travelnet '@2' (owned by @3)" .. " " ..
+				"ready for usage.",
+				tostring(new_station_name or station_name),
+				tostring(new_station_network or station_network),
+				tostring(new_owner_name or owner_name)
+			))
 
 	-- save the updated network data in a savefile over server restart
 	travelnet.save_data()

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -1,6 +1,8 @@
 local S = minetest.get_translator("travelnet")
 
-local function on_receive_fields_internal(pos, _, fields, player)
+local player_formspec_data = travelnet.player_formspec_data
+
+local function on_receive_fields_internal(pos, fields, player)
 	if not pos then
 		return
 	end
@@ -244,11 +246,22 @@ local function on_receive_fields_internal(pos, _, fields, player)
 
 end
 
-local player_formspec_data = travelnet.player_formspec_data
 function travelnet.on_receive_fields(pos, _, fields, player)
 	local name = player:get_player_name()
-	player_formspec_data[name] = {wait_mode=true}
-	on_receive_fields_internal(pos, _, fields, player)
-	travelnet.show_formspec(name)
-	player_formspec_data[name] = nil
+	player_formspec_data[name] = player_formspec_data[name] or {}
+	if pos then
+		player_formspec_data[name].pos = pos
+	else
+		pos = player_formspec_data[name].pos
+	end
+
+	player_formspec_data[name].wait_mode = true
+	on_receive_fields_internal(pos, fields, player)
+
+	local closed = not travelnet.show_formspec(name)
+	if fields.quit or closed then
+		player_formspec_data[name] = nil
+	else
+		player_formspec_data[name].wait_mode = nil
+	end
 end

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -175,7 +175,7 @@ local function on_receive_fields_internal(pos, fields, player)
 				S("Station '@1' does not exist (anymore?)" ..
 					" " .. "on this network.", fields.target or "?")
 		)
-		travelnet.page_formspec(pos, player_name)
+		travelnet.show_current_formspec(pos, nil, name)
 		return
 	end
 

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -142,7 +142,7 @@ local function on_receive_fields_internal(pos, fields, player)
 
 	-- the owner or players with the travelnet_attach priv can move stations up or down in the list
 	if fields.move_up or fields.move_down then
-		travelnet.update_formspec(pos, name, fields)
+		travelnet.change_order(pos, name, fields)
 		return
 	end
 
@@ -175,7 +175,7 @@ local function on_receive_fields_internal(pos, fields, player)
 				S("Station '@1' does not exist (anymore?)" ..
 					" " .. "on this network.", fields.target or "?")
 		)
-		travelnet.update_formspec(pos, name, nil)
+		travelnet.page_formspec(pos, player_name)
 		return
 	end
 

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -15,6 +15,10 @@ local function on_interact(pos, _, player)
 	local meta = minetest.get_meta(pos)
 	local station_network = meta:get_string("station_network")
 	local player_name = player:get_player_name()
+	local legacy_formspec = meta:get_string("formspec")
+	if not travelnet.is_falsey_string(legacy_formspec) then
+		meta:set_string("formspec", "")
+	end
 
 	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
 	player_formspec_data[player_name].pos = pos

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -53,7 +53,7 @@ local function on_interact(pos, _, player)
 				)
 		)
 	else
-		travelnet.page_formspec(pos, player_name)
+		travelnet.show_current_formspec(pos, nil, player_name)
 	end
 end
 

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -7,7 +7,55 @@
 
 local S = minetest.get_translator("travelnet")
 
+local player_formspec_data = travelnet.player_formspec_data
+
 local travelnet_dyes = {}
+
+local function on_interact(pos, _, player)
+	local meta = minetest.get_meta(pos)
+	local station_network = meta:get_string("station_network")
+	local player_name = player:get_player_name()
+
+	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
+	player_formspec_data[player_name].pos = pos
+
+	if travelnet.is_falsey_string(station_network) then
+		-- some players seem to be confused with entering network names at first; provide them
+		-- with a default name
+		local default_network = "net1"
+
+		-- request initinal data
+		travelnet.set_formspec(player_name,
+				([[
+					size[10,6.0]
+					label[2.0,0.0;--> %s <--]
+					button[8.0,0.0;2.2,0.7;station_dig;%s]
+					field[0.3,1.2;9,0.9;station_name;%s:;]
+					label[0.3,1.5;%s]
+					field[0.3,2.8;9,0.9;station_network;%s;%s]
+					label[0.3,3.1;%s]
+					field[0.3,4.4;9,0.9;owner;%s;]
+					label[0.3,4.7;%s]
+					button[3.8,5.3;1.7,0.7;station_set;%s]
+					button[6.3,5.3;1.7,0.7;station_exit;%s]
+				]]):format(
+					S("Configure this travelnet station"),
+					S("Remove station"),
+					S("Name of this station"),
+					S("How do you call this place here? Example: \"my first house\", \"mine\", \"shop\"..."),
+					S("Assign to Network:"),
+					default_network,
+					S("You can have more than one network. If unsure, use \"@1\".", default_network),
+					S("Owned by:"),
+					S("Unless you know what you are doing, leave this empty."),
+					S("Save"),
+					S("Exit")
+				)
+		)
+	else
+		travelnet.page_formspec(pos, player_name)
+	end
+end
 
 -- travelnet box register function
 function travelnet.register_travelnet_box(cfg)
@@ -53,12 +101,15 @@ function travelnet.register_travelnet_box(cfg)
 		light_source = cfg.light_source or 10,
 		after_place_node = function(pos, placer)
 			local meta = minetest.get_meta(pos)
-			travelnet.reset_formspec(meta)
+			meta:set_string("infotext",       S("Travelnet-box (unconfigured)"))
+			meta:set_string("station_name",   "")
+			meta:set_string("station_network","")
 			meta:set_string("owner", placer:get_player_name())
 			minetest.set_node(vector.add(pos, { x=0, y=1, z=0 }), { name="travelnet:hidden_top" })
 		end,
 
 		on_receive_fields = travelnet.on_receive_fields,
+		on_rightclick = on_interact,
 		on_punch = function(pos, node, puncher)
 			local item = puncher:get_wielded_item()
 			local item_name = item:get_name()
@@ -74,7 +125,7 @@ function travelnet.register_travelnet_box(cfg)
 				puncher:set_wielded_item(item)
 				return
 			end
-			travelnet.update_formspec(pos, player_name, nil)
+			on_interact(pos, nil, puncher)
 		end,
 
 		can_dig = function(pos, player)

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -25,10 +25,10 @@ function travelnet.primary_formspec(pos, puncher_name, _, page_number)
 		return
 	end
 
+
+	local network = travelnet.get_or_create_network(owner_name, station_network)
 	-- if the station got lost from the network for some reason (savefile corrupted?) then add it again
 	if not travelnet.get_station(owner_name, station_network, station_name) then
-
-		local network = travelnet.get_or_create_network(owner_name, station_network)
 
 		local zeit = meta:get_int("timestamp")
 		if not zeit or type(zeit) ~= "number" or zeit < 100000 then
@@ -78,46 +78,7 @@ function travelnet.primary_formspec(pos, puncher_name, _, page_number)
 	local i = 0
 
 	-- collect all station names in a table
-	local stations = {}
-	local network = travelnet.targets[owner_name][station_network]
-
-	for k in pairs(network) do
-		table.insert(stations, k)
-	end
-
-	local ground_level = 1
-	if is_elevator then
-		table.sort(stations, function(a, b)
-			return network[a].pos.y > network[b].pos.y
-		end)
-
-		-- find ground level
-		local vgl_timestamp = 999999999999
-		for index,k in ipairs(stations) do
-			local station = network[k]
-			if not station.timestamp then
-				station.timestamp = os.time()
-			end
-			if station.timestamp < vgl_timestamp then
-				vgl_timestamp = station.timestamp
-				ground_level  = index
-			end
-		end
-
-		for index,k in ipairs(stations) do
-			local station = network[k]
-			if index == ground_level then
-				station.nr = "G"
-			else
-				station.nr = tostring(ground_level - index)
-			end
-		end
-	else
-		-- sort the table according to the timestamp (=time the station was configured)
-		table.sort(stations, function(a, b)
-			return network[a].timestamp < network[b].timestamp
-		end)
-	end
+	local stations = travelnet.get_ordered_stations(owner_name, station_network, is_elevator)
 
 	-- if there are only 8 stations (plus this one), center them in the formspec
 	if #stations < 10 then

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -1,5 +1,7 @@
 local S = minetest.get_translator("travelnet")
 
+local player_formspec_data = travelnet.player_formspec_data
+
 local function is_falsey_string(str)
 	return not str or str == ""
 end
@@ -290,6 +292,9 @@ function travelnet.update_formspec(pos, puncher_name, fields)
 				"on travelnet '@2' (owned by @3)" .. " " ..
 				"ready for usage. Right-click to travel, punch to update.",
 				tostring(station_name), tostring(station_network), tostring(owner_name)))
+
+	player_formspec_data[puncher_name] = player_formspec_data[puncher_name] or {}
+	player_formspec_data[puncher_name].pos = pos
 
 	-- show the player the updated formspec
 	travelnet.show_current_formspec(pos, meta, puncher_name)

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -1,8 +1,6 @@
 local S = minetest.get_translator("travelnet")
 
-local player_formspec_data = travelnet.player_formspec_data
-
-function travelnet.primary_formspec(pos, puncher_name, fields, page_number)
+function travelnet.primary_formspec(pos, puncher_name, _, page_number)
 
 	local meta = minetest.get_meta(pos)
 
@@ -213,6 +211,8 @@ function travelnet.primary_formspec(pos, puncher_name, fields, page_number)
 	return formspec
 end
 
-function travelnet.update_formspec(pos, puncher_name, fields)
-	minetest.log("warning", "[travelnet] the travelnet.update_formspec method is deprecated. The formspec is now generated on each interaction.")
+function travelnet.update_formspec()
+	minetest.log("warning",
+		"[travelnet] the travelnet.update_formspec method is deprecated. "..
+		"The formspec is now generated on each interaction.")
 end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -259,7 +259,6 @@ function travelnet.primary_formspec(pos, puncher_name, fields, page_number)
 		formspec = formspec
 			.. ("label[5,9.4;%s]"):format(minetest.formspec_escape(S("Page @1/@2", page_number, pages)))
 			.. ("field[20,20;0.1,0.1;page_number;Page;%i]"):format(page_number)
-			.. ("field[20,20;0.1,0.1;pos2str;Pos;%s]"):format(minetest.pos_to_string(pos))
 		if page_number < pages then
 			formspec = formspec .. ("button[8,9.2;2,1;next_page;%s]"):format(minetest.formspec_escape(S(">")))
 		end

--- a/update_formspec.lua
+++ b/update_formspec.lua
@@ -21,8 +21,6 @@ function travelnet.primary_formspec(pos, puncher_name, _, page_number)
 			travelnet.add_target(nil, nil, pos, puncher_name, meta, owner_name)
 			return
 		end
-
-		-- travelnet.reset_formspec(meta)
 		travelnet.show_message(pos, puncher_name, "Error", S("Update failed! Resetting this box on the travelnet."))
 		return
 	end


### PR DESCRIPTION
Fixes #39 

This is based on https://github.com/mt-mods/travelnet/pull/44/files to avoid duplicating work

- `update_formspec` and `reset_formspec` deprecated as they would only update metadata
- Uses same behaviour on punch and right click - no need to act differently anymore
- Move "Move Up" and "Move Down" behaviour out of `primary_formspec` to its own function