### PR TITLE
add lbm to migrate formspecs automatically on mapblock load

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -63,6 +63,9 @@ mod_dofile("add_target")
 -- receive fields handler
 mod_dofile("on_receive_fields")
 
+-- meta-formspec migration lbm
+mod_dofile("migrate_formspecs_lbm")
+
 -- invisible node to place inside top of travelnet box and elevator
 minetest.register_node("travelnet:hidden_top", {
 	drawtype = "nodebox",

--- a/migrate_formspecs_lbm.lua
+++ b/migrate_formspecs_lbm.lua
@@ -1,0 +1,14 @@
+
+minetest.register_lbm({
+    label = "Migrate travelnet formspecs from meta to rightclick/punch-only",
+    name = "travelnet:migrate_formspecs",
+    nodenames = {"group:travelnet"},
+    action = function(pos)
+        -- check formspec meta-field and clear it
+        local meta = minetest.get_meta(pos)
+        local legacy_formspec = meta:get_string("formspec")
+        if not travelnet.is_falsey_string(legacy_formspec) then
+            meta:set_string("formspec", "")
+        end
+    end
+})


### PR DESCRIPTION
in addition to #47 this will migrate the old formspec in meta to the new rightclick-/punch-only behavior automatically
(the formspec flashes were getting annoying)