### PR TITLE
Move assignment of pos from on_interact methods to inside show_current_formspec method

### DIFF
--- a/elevator.lua
+++ b/elevator.lua
@@ -3,8 +3,6 @@
 -- Author: Sokomine
 local S = minetest.get_translator("travelnet")
 
-local player_formspec_data = travelnet.player_formspec_data
-
 function travelnet.show_nearest_elevator(pos, owner_name, param2)
 	if not pos or not pos.x or not pos.z or not owner_name then
 		return
@@ -80,8 +78,6 @@ local function on_interact(pos, _, player)
 	end
 
 	local player_name = player:get_player_name()
-	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
-	player_formspec_data[player_name].pos = pos
 	travelnet.show_current_formspec(pos, meta, player_name)
 end
 

--- a/formspecs-legacy.lua
+++ b/formspecs-legacy.lua
@@ -1,5 +1,7 @@
 local travelnet_form_name = "travelnet:show"
 
+local player_formspec_data = travelnet.player_formspec_data
+
 -- minetest.chat_send_player is sometimes not so well visible
 function travelnet.show_message(pos, player_name, title, message)
 	if not pos or not player_name or not message then
@@ -15,6 +17,8 @@ end
 -- show the player the formspec they would see when right-clicking the node;
 -- needs to be simulated this way as calling on_rightclick would not do
 function travelnet.show_current_formspec(pos, meta, player_name)
+	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
+	player_formspec_data[player_name].pos = pos
 	local node = minetest.get_node(pos)
 	travelnet.show_formspec(player_name,
 		travelnet.formspecs.current({

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -7,8 +7,6 @@
 
 local S = minetest.get_translator("travelnet")
 
-local player_formspec_data = travelnet.player_formspec_data
-
 local travelnet_dyes = {}
 
 local function on_interact(pos, _, player)
@@ -19,8 +17,6 @@ local function on_interact(pos, _, player)
 	end
 
 	local player_name = player:get_player_name()
-	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
-	player_formspec_data[player_name].pos = pos
 	travelnet.show_current_formspec(pos, meta, player_name)
 end
 


### PR DESCRIPTION
So I'm trying to make sure the locked tarvelnet mod  https://github.com/BlockySurvival/locked_travelnet is working with the most recent changes. Though the way it works (in locked_travelnet) could do with an overhaul I seem to be able to get it to mostly work.

I will be merging these changes immediately as they are pretty small, really just reduce repetition, and are mostly a matter of preference anyway... also I want to get this bug fixed.

These changes are required because an external mod (such as locked_travelnet) cannot have access to the internal data storage of the travelnet form data, instead of relying on having that in the on_interact method, I have moved it to the show_current_formspec method so that an external mod can just call that.

Perhaps the ideal solution would be to add a new `set_data_pos(pos)` method to the API or something, but for now this should work fine.