### PR TITLE
Add repair button

### DIFF
--- a/actions/repair_station.lua
+++ b/actions/repair_station.lua
@@ -1,7 +1,7 @@
 local S = minetest.get_translator("travelnet")
 
 return function (node_info, _, player)
-	local owner_name      = node_info.props.owner
+	local owner_name      = node_info.props.owner_name
 	local station_name    = node_info.props.station_name
 	local station_network = node_info.props.station_network
 

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -204,8 +204,10 @@ function travelnet.formspecs.primary(options, player_name)
 	then
 		formspec = formspec .. ([[
 				button[10.0,0.5;2.2,0.7;station_edit;%s]
+				button[9.5,0;2,0.5;station_repair;%s]
 			]]):format(
-				S("Edit station")
+				S("Edit station"),
+				S("Repair")
 			)
 	end
 

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -47,6 +47,10 @@ local function decide_action(fields, props)
 		return travelnet.actions.return_to_form
 	end
 
+	if fields.station_repair then
+		return travelnet.actions.repair_station
+	end
+
 	-- if paging is enabled and the player wants to change pages
 	if (travelnet.MAX_STATIONS_PER_NETWORK == 0 or travelnet.MAX_STATIONS_PER_NETWORK > 24)
 		and fields.page_number


### PR DESCRIPTION
Since #45 we no longer go through the old `update_formspec` logic which would automatically repair stations on punch.

I have also recently found all the travelnets I configured missing from their networks - which is exactly what this repair behaviour is intended to fix.

To re-allow the repair behaviour, I have added a button to the top right of the primary formspec that allows you to run the repair logic.

The same thing cannot be achieved by editing and re-saving the travelnet data because it does nothing if no data has changed, the repair logic is required.

The downside to this is that the form is getting a little cramped, I'm going to bring this up in an issue elsewhere https://github.com/mt-mods/travelnet/issues/53