### PR TITLE
Attempt to repair the station each time the primary formspec is opened

### DIFF
--- a/actions/repair_station.lua
+++ b/actions/repair_station.lua
@@ -1,7 +1,7 @@
 local S = minetest.get_translator("travelnet")
 
 return function (node_info, _, player)
-	local owner_name      = node_info.props.owner
+	local owner_name      = node_info.props.owner_name
 	local station_name    = node_info.props.station_name
 	local station_network = node_info.props.station_network
 
@@ -22,6 +22,20 @@ return function (node_info, _, player)
 		local zeit = node_info.meta:get_int("timestamp")
 		if not zeit or type(zeit) ~= "number" or zeit < 100000 then
 			zeit = os.time()
+		end
+
+		local station_count = 1  -- start at one, assume the station about to be created already exists
+		for existing_station_name in pairs(network) do
+			if existing_station_name == station_name then
+				return false, S("A station named '@1' already exists on this network. Please choose a different name!", station_name)
+			end
+			station_count = station_count+1
+		end
+
+		-- we don't want too many stations in the same network because that would get confusing when displaying the targets
+		if travelnet.MAX_STATIONS_PER_NETWORK ~= 0 and station_count > travelnet.MAX_STATIONS_PER_NETWORK then
+			return false, S("Network '@1', already contains the maximum number (@2) of allowed stations per network. " ..
+				"Please choose a different/new network name.", station_network, travelnet.MAX_STATIONS_PER_NETWORK)
 		end
 
 		-- add this station

--- a/formspecs-legacy.lua
+++ b/formspecs-legacy.lua
@@ -1,3 +1,5 @@
+local S = minetest.get_translator("travelnet")
+
 local travelnet_form_name = "travelnet:show"
 
 local player_formspec_data = travelnet.player_formspec_data
@@ -20,13 +22,27 @@ function travelnet.show_current_formspec(pos, meta, player_name)
 	player_formspec_data[player_name] = player_formspec_data[player_name] or {}
 	player_formspec_data[player_name].pos = pos
 	local node = minetest.get_node(pos)
+	local props = {
+		station_network = meta:get_string("station_network"),
+		station_name = meta:get_string("station_name"),
+		owner_name = meta:get_string("owner"),
+		is_elevator = travelnet.is_elevator(node.name)
+	}
+	if not travelnet.is_falsey_string(props.station_network) then
+		local success, result = travelnet.actions.repair_station({
+			pos = pos,
+			meta = meta,
+			node = node,
+			props = props
+		}, {}, minetest.get_player_by_name(player_name))
+
+		if not success then
+			minetest.chat_send_player(player_name, S("Error") .. ": " .. result)
+		end
+	end
+
 	travelnet.show_formspec(player_name,
-		travelnet.formspecs.current({
-			station_network = meta:get_string("station_network"),
-			station_name = meta:get_string("station_name"),
-			owner_name = meta:get_string("owner"),
-			is_elevator = travelnet.is_elevator(node.name)
-		}, player_name))
+		travelnet.formspecs.current(props, player_name))
 end
 
 -- a player clicked on something in the formspec hse was manually shown


### PR DESCRIPTION
This PR runs the repair action each time the form is opened, except when it has not yet been configured.

I also fixed the repair logic and added in a condition to stop the max network count being exceeded, or a duplicate network being added. Any error when re-attaching the station will be reported via chat, and the primary formspec shown anyway so the player can remove the station if needed.

In my opinion https://github.com/mt-mods/travelnet/pull/52 (adding a repair button) is much preferred because:

- Only someone with permissions can run the repair logic
- The repair logic is run intentionally, not all the time
- Formspec error messages can be used, instead of a mix of formspec & chat

All these things improve the user experience of re-attaching the network