### PR TITLE
Consistently rename owner to owner_name (except metadata prop); Move a line below a condition to avoid crash.

### DIFF
--- a/actions/repair_station.lua
+++ b/actions/repair_station.lua
@@ -1,7 +1,7 @@
 local S = minetest.get_translator("travelnet")
 
 return function (node_info, _, player)
-	local owner_name      = node_info.props.owner
+	local owner_name      = node_info.props.owner_name
 	local station_name    = node_info.props.station_name
 	local station_network = node_info.props.station_network
 

--- a/actions/transport_player.lua
+++ b/actions/transport_player.lua
@@ -81,7 +81,7 @@ return function (node_info, fields, player)
 		-- provide information necessary to identify the removed box
 		local oldmetadata = {
 			fields = {
-				owner           = node_info.props.owner_name,
+				owner_name      = node_info.props.owner_name,
 				station_name    = fields.target,
 				station_network = node_info.props.station_network
 			}

--- a/actions/update_travelnet.lua
+++ b/actions/update_travelnet.lua
@@ -20,7 +20,7 @@ return function (node_info, fields, player)
 		return false, S("Unknown node.")
 	end
 
-	if owner_name == fields.owner
+	if owner_name == fields.owner_name
 		and station_network == fields.station_network
 		and station_name == fields.station_name
 	then
@@ -36,7 +36,7 @@ return function (node_info, fields, player)
 		error_message = error_message .. ' '
 			..S('Please provide a network name.')
 	end
-	if travelnet.is_falsey_string(fields.owner) then
+	if travelnet.is_falsey_string(fields.owner_name) then
 		error_message = error_message .. ' '
 			..S('Please provide an owner.')
 	end
@@ -72,15 +72,15 @@ return function (node_info, fields, player)
 
 	local network
 	local timestamp = os.time()
-	if owner_name ~= fields.owner then
+	if owner_name ~= fields.owner_name then
 		-- new owner -> remove station from old network then add to new owner
 		-- but only if there is space on the network
 		-- get the new network
-		network = travelnet.get_or_create_network(fields.owner, fields.station_network)
+		network = travelnet.get_or_create_network(fields.owner_name, fields.station_network)
 		-- does a station with the new name already exist?
 		if network[fields.station_name] then
 			return false, S('Station "@1" already exists on network "@2" of player "@3".',
-					fields.station_name, fields.station_network, fields.owner)
+					fields.station_name, fields.station_network, fields.owner_name)
 		end
 		-- does the new network have space at all?
 		if travelnet.MAX_STATIONS_PER_NETWORK ~= 0 and 1 + #network > travelnet.MAX_STATIONS_PER_NETWORK then
@@ -104,7 +104,7 @@ return function (node_info, fields, player)
 		-- update meta
 		meta:set_string("station_name",    fields.station_name)
 		meta:set_string("station_network", fields.station_network)
-		meta:set_string("owner",           fields.owner)
+		meta:set_string("owner",           fields.owner_name)
 		meta:set_int   ("timestamp",       timestamp)
 
 		minetest.chat_send_player(player_name,
@@ -113,9 +113,9 @@ return function (node_info, fields, player)
 				.. 'and from owner "@5" to owner "@6".',
 				station_name, fields.station_name,
 				station_network, fields.station_network,
-				owner_name, fields.owner))
+				owner_name, fields.owner_name))
 
-		new_owner_name = fields.owner
+		new_owner_name = fields.owner_name
 		new_station_network = fields.station_network
 		new_station_name = fields.station_name
 	elseif station_network ~= fields.station_network then

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -51,7 +51,7 @@ function travelnet.formspecs.edit_travelnet(options)
 		label[0.3,1.5;%s]
 		field[0.3,2.8;9,0.9;station_network;%s;%s]
 		label[0.3,3.1;%s]
-		field[0.3,4.4;9,0.9;owner;%s;%s]
+		field[0.3,4.4;9,0.9;owner_name;%s;%s]
 		label[0.3,4.7;%s]
 		button[3.8,5.3;1.7,0.7;station_set;%s]
 		button[6.3,5.3;1.7,0.7;station_exit;%s]

--- a/functions.lua
+++ b/functions.lua
@@ -310,7 +310,7 @@ travelnet.remove_box = function(_, _, oldmetadata, digger)
 		return
 	end
 
-	local owner_name      = oldmetadata.fields["owner"]
+	local owner_name      = oldmetadata.fields["owner_name"]
 	local station_name    = oldmetadata.fields["station_name"]
 	local station_network = oldmetadata.fields["station_network"]
 

--- a/on_receive_fields.lua
+++ b/on_receive_fields.lua
@@ -140,13 +140,13 @@ function travelnet.on_receive_fields(pos, _, fields, player)
 
 	-- Validate node's meta data
 	local valid, props = validate_travelnet(pos, meta)
-	props.is_elevator = travelnet.is_elevator(node.name)
 	if not valid then
 		minetest.chat_send_player(name, props)
 		travelnet.actions.end_input(action_args, fields, player)
 		travelnet.show_formspec(name, false)
 		return
 	end
+	props.is_elevator = travelnet.is_elevator(node.name)
 	action_args.props = props
 
 	-- Decide which action to run based on fields given


### PR DESCRIPTION
It is currently impossible to set the owner when creating a travelnet because of a confusion with naming conventions.

All instances of `owner` have now been changed to `owner_name`, except for the metadata property of the travelnet, which should not be changed for backward-compatibility reasons.


We also ran into a crash recently:
`2022-06-09 10:52:06: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'travelnet' in callback on_playerReceiveFields(): ...e/billys/bls/bin/../mods/travelnet/on_receive_fields.lua:143: attempt to index local 'props' (a string value)`

Which is caused by accessing props as if it's a table when the validation has actually failed, I just moved that line below the condition to fix this.