### PR TITLE
Fix travelnet removal issue and cleanup removal code

### DIFF
--- a/actions/main.lua
+++ b/actions/main.lua
@@ -60,12 +60,11 @@ function travelnet.actions.remove_station(node_info, _, player)
 	if not player_inventory:room_for_item("main", node_info.node.name) then
 		return false, S("You do not have enough room in your inventory.")
 	end
+
 	-- give the player the box
 	player_inventory:add_item("main", node_info.node.name)
-
 	-- remove the box from the data structure
-	travelnet.remove_box(node_info.pos, nil, oldmetadata, player)
-
+	travelnet.remove_box(node_info.pos, nil, node_info.meta:to_table(), player)
 	-- remove the node as such
 	minetest.remove_node(node_info.pos)
 

--- a/actions/main.lua
+++ b/actions/main.lua
@@ -61,12 +61,21 @@ function travelnet.actions.remove_station(node_info, _, player)
 		return false, S("You do not have enough room in your inventory.")
 	end
 
+	local oldmetadata = node_info.meta:to_table()
+	-- remove the box from the data structure
+	local success, reason = travelnet.remove_box_action(oldmetadata)
+
+	if not success then
+		return false, reason
+	end
 	-- give the player the box
 	player_inventory:add_item("main", node_info.node.name)
-	-- remove the box from the data structure
-	travelnet.remove_box(node_info.pos, nil, node_info.meta:to_table(), player)
+
 	-- remove the node as such
 	minetest.remove_node(node_info.pos)
+
+	-- inform the owner
+	travelnet.remove_box_message(oldmetadata, player)
 
 	return true
 end

--- a/actions/main.lua
+++ b/actions/main.lua
@@ -60,22 +60,14 @@ function travelnet.actions.remove_station(node_info, _, player)
 	if not player_inventory:room_for_item("main", node_info.node.name) then
 		return false, S("You do not have enough room in your inventory.")
 	end
-
-	local oldmetadata = node_info.meta:to_table()
-	-- remove the box from the data structure
-	local success, reason = travelnet.remove_box_action(oldmetadata)
-
-	if not success then
-		return false, reason
-	end
 	-- give the player the box
 	player_inventory:add_item("main", node_info.node.name)
 
+	-- remove the box from the data structure
+	travelnet.remove_box(node_info.pos, nil, oldmetadata, player)
+
 	-- remove the node as such
 	minetest.remove_node(node_info.pos)
-
-	-- inform the owner
-	travelnet.remove_box_message(oldmetadata, player)
 
 	return true
 end

--- a/actions/transport_player.lua
+++ b/actions/transport_player.lua
@@ -87,7 +87,12 @@ return function (node_info, fields, player)
 			}
 		}
 
-		travelnet.remove_box(target_pos, nil, oldmetadata, player)
+		local success, reason = travelnet.remove_box_action(oldmetadata)
+		if not success then
+			return false, reason
+		end
+
+		travelnet.remove_box_message(oldmetadata, player)
 	else
 		player:move_to(vector.add(target_pos, player_model_vec), false)
 		travelnet.rotate_player(target_pos, player)


### PR DESCRIPTION
Fixes https://github.com/mt-mods/travelnet/issues/57

The issue here was that after this MR https://github.com/mt-mods/travelnet/pull/56 I accidentally changed one instance of `"owner"` to `"owner_name"` that was referring to metadata, not formspec fields. The error was made because the metadata is serialised, so is a table with the `fields` property, I interpreted this as formspec fields instead of metadata so didn't correct it when reviewing the code.

Incorrect. We want it to remove the station if the data is broken. ~~I've cleaned up the code a little as I noticed we don't technically detect all failures and may actually give a player an item when the removal actually fails.~~

I split up the `travelnet.remove_box` method into `travelnet.remove_box_action` and `travelnet.remove_box_message`, separating out the action lets us tell if it's succeeded or not before continuing. It also brings it closer in line with the high-level actions, which respond in the same way on failure

`travelnet.remove_box` is kept, and simply calls into those new methods to replicate the old behaviour