### PR TITLE
MineClone 2 adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 ## How this works
 
-- craft it by filling the right and left row with glass; place in the middle row (from top to bottom): steel, mese, steel
+- craft it by filling the right and left column with glass; place in the middle column (from top to bottom): steel, mese, steel
+  - MineClone 2: use a redstone block instead of mese
 - place the travelnet box somewhere
 - right-click on it; enter name of the station (e.g. "my house", "center of desert city") and name of the network (e.g. "intresting towns","my buildings")
 - punch it to update the list of stations on that network

--- a/config.lua
+++ b/config.lua
@@ -45,30 +45,15 @@ travelnet.elevator_inventory_image  = "travelnet_elevator_inv.png"
 
 if minetest.registered_nodes["mcl_core:wood"] then
 	travelnet.travelnet_recipe = {
-		{ "mcl_stairs:slab_wood",            "mcl_stairs:slab_wood", "mcl_stairs:slab_wood" },
-		{ "mesecons_torch:mesecon_torch_on", "mcl_chests:chest",     "mesecons_torch:mesecon_torch_on" },
-		{ "mesecons_torch:mesecon_torch_on", "mcl_chests:chest",     "mesecons_torch:mesecon_torch_on" },
-		-- { "core:glass",     "mcl_core:iron_ingot",          "mcl_core:glass" },
-		-- { "mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass" },
-		-- { "mcl_core:glass", "mcl_core:iron_ingot",          "mcl_core:glass" }
+		{ "mcl_core:glass", "mcl_core:iron_ingot",          "mcl_core:glass" },
+		{ "mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass" },
+		{ "mcl_core:glass", "mcl_core:iron_ingot",          "mcl_core:glass" }
 	}
 	travelnet.elevator_recipe = {
-		{ "mcl_stairs:slab_wood", "mcl_stairs:slab_wood", "mcl_stairs:slab_wood" },
-		{ "mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on" },
-		{ "mesecons_torch:mesecon_torch_on", "", "mesecons_torch:mesecon_torch_on" },
-		-- { "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" },
-		-- { "mcl_core:iron_ingot", "",               "mcl_core:iron_ingot" },
-		-- { "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" }
+		{ "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" },
+		{ "mcl_core:iron_ingot", "",               "mcl_core:iron_ingot" },
+		{ "mcl_core:iron_ingot", "mcl_core:glass", "mcl_core:iron_ingot" }
 	}
-	travelnet.tiles_elevator = {
-		"mcl_core_planks_big_oak.png^[transformR90", -- front
-		"mcl_core_planks_big_oak.png^[transformR90", -- inside
-		"mcl_core_planks_big_oak.png^[transformR90", -- sides outside
-		"mcl_core_planks_big_oak.png^[transformR90", -- inside ceiling
-		"mcl_core_planks_big_oak.png^[transformR90", -- inside floor
-		"mcl_core_planks_big_oak.png^[transformR90", -- top
-	}
-	travelnet.elevator_inventory_image = nil
 end
 
 -- if this function returns true, the player with the name player_name is

--- a/doors.lua
+++ b/doors.lua
@@ -123,4 +123,9 @@ if minetest.get_modpath("default") then
 	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },           "default:steel_ingot")
 	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass")
 	travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },              "default:tin_ingot")
+
+elseif minetest.registered_nodes["mcl_core:wood"] then
+	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },           "mcl_core:iron_ingot")
+	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "mcl_core:glass")
+	-- travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },              "default:tin_ingot")
 end


### PR DESCRIPTION
- Do not use the wooden box texture for travelnet boxes
- Use nearly the same ingredients for boxes (diamond block instead of mese)
- Enable doors