### PR TITLE
don't allow random players to attach travelnets to other players' networks

### DIFF
--- a/actions/update_travelnet.lua
+++ b/actions/update_travelnet.lua
@@ -73,7 +73,8 @@ return function (node_info, fields, player)
 	local network
 	local timestamp = os.time()
 	if owner_name ~= fields.owner_name then
-		if not minetest.check_player_privs(player_name, { travelnet_attach = true }) then
+		if not minetest.check_player_privs(player_name, { travelnet_attach = true })
+			and not travelnet.allow_attach(player_name, owner_name, fields.station_network) then
 			minetest.record_protection_violation(pos, player_name)
 			return false, S("You don't have permission to change the owner of this travelnet")
 		end

--- a/actions/update_travelnet.lua
+++ b/actions/update_travelnet.lua
@@ -73,6 +73,11 @@ return function (node_info, fields, player)
 	local network
 	local timestamp = os.time()
 	if owner_name ~= fields.owner_name then
+		if not minetest.check_player_privs(player_name, { travelnet_attach = true }) then
+			minetest.record_protection_violation(pos, player_name)
+			return false, S("You don't have permission to change the owner of this travelnet")
+		end
+
 		-- new owner -> remove station from old network then add to new owner
 		-- but only if there is space on the network
 		-- get the new network


### PR DESCRIPTION
currently, any player can add a travelnet to another player's network by changing the owner of one of their existing boxen. this prevents that.