### PR TITLE
fix crashes due not send itemstacks

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -6,6 +6,7 @@ read_globals = {
 	-- Minetest
 	"minetest",
 	"vector",
+	"ItemStack",
 
 	-- Deps
 	"creative", "mesecon", "mtt"

--- a/doors.lua
+++ b/doors.lua
@@ -21,7 +21,8 @@ function travelnet.register_door(node_base_name, def_tiles, material)
 			snappy = 2,
 			choppy = 2,
 			oddly_breakable_by_hand = 2,
-			not_in_creative_inventory = 1
+			not_in_creative_inventory = 1,
+			door = 1
 		},
 		-- larger than one node but slightly smaller than a half node so
 		-- that wallmounted torches pose no problem
@@ -58,7 +59,8 @@ function travelnet.register_door(node_base_name, def_tiles, material)
 		groups = {
 			snappy = 2,
 			choppy = 2,
-			oddly_breakable_by_hand = 2
+			oddly_breakable_by_hand = 2,
+			door = 1
 		},
 		node_box = {
 			type = "fixed",

--- a/functions.lua
+++ b/functions.lua
@@ -257,11 +257,13 @@ function travelnet.open_close_door(pos, player, mode)
 			-- Get the player again in case it doesn't exist anymore (logged out)
 			local pplayer = minetest.get_player_by_name(playername)
 			if pplayer then
-				right_click_action(door_pos, door_node, pplayer, pplayer:get_wielded_item())
+				local stack = player:get_wielded_item()
+				player:set_wielded_item(right_click_action(door_pos, door_node, pplayer, stack) or stack)
 			end
 		end)
 	else
-		right_click_action(door_pos, door_node, player, player:get_wielded_item())
+		local stack = player:get_wielded_item()
+		player:set_wielded_item(right_click_action(door_pos, door_node, player, stack) or stack)
 	end
 end
 

--- a/functions.lua
+++ b/functions.lua
@@ -257,11 +257,11 @@ function travelnet.open_close_door(pos, player, mode)
 			-- Get the player again in case it doesn't exist anymore (logged out)
 			local pplayer = minetest.get_player_by_name(playername)
 			if pplayer then
-				right_click_action(door_pos, door_node, pplayer)
+				right_click_action(door_pos, door_node, pplayer, pplayer:get_wielded_item())
 			end
 		end)
 	else
-		right_click_action(door_pos, door_node, player)
+		right_click_action(door_pos, door_node, player, player:get_wielded_item())
 	end
 end
 

--- a/functions.lua
+++ b/functions.lua
@@ -257,8 +257,8 @@ function travelnet.open_close_door(pos, player, mode)
 			-- Get the player again in case it doesn't exist anymore (logged out)
 			local pplayer = minetest.get_player_by_name(playername)
 			if pplayer then
-				local stack = player:get_wielded_item()
-				player:set_wielded_item(right_click_action(door_pos, door_node, pplayer, stack) or stack)
+				local stack = pplayer:get_wielded_item()
+				pplayer:set_wielded_item(right_click_action(door_pos, door_node, pplayer, stack) or stack)
 			end
 		end)
 	else

--- a/functions.lua
+++ b/functions.lua
@@ -234,6 +234,10 @@ function travelnet.open_close_door(pos, player, mode)
 	local right_click_action = minetest.registered_nodes[door_node.name].on_rightclick
 	if not right_click_action then return end
 
+	if not minetest.registered_nodes[door_node.name].groups["door"] then
+		return
+	end
+
 	-- Map to old API in case anyone is using it externally
 	if     mode == 0 then mode = "toggle"
 	elseif mode == 1 then mode = "close"
@@ -257,13 +261,11 @@ function travelnet.open_close_door(pos, player, mode)
 			-- Get the player again in case it doesn't exist anymore (logged out)
 			local pplayer = minetest.get_player_by_name(playername)
 			if pplayer then
-				local stack = pplayer:get_wielded_item()
-				pplayer:set_wielded_item(right_click_action(door_pos, door_node, pplayer, stack) or stack)
+				right_click_action(door_pos, door_node, pplayer, ItemStack(""))
 			end
 		end)
 	else
-		local stack = player:get_wielded_item()
-		player:set_wielded_item(right_click_action(door_pos, door_node, player, stack) or stack)
+		right_click_action(door_pos, door_node, player, ItemStack(""))
 	end
 end
 


### PR DESCRIPTION
many mods crash because they don't check if the itemstack is valid (or nil). This patch fixes that.
Look at this: https://github.com/mt-mods/home_workshop_modpack/issues/12

Please test this well