### PR TITLE
add `/travelnet` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ See [settingtypes.txt](https://github.com/mt-mods/travelnet/blob/master/settingt
 ![](screenshot_day.png)
 ![](screenshot_night.png)
 
+## Chatcommands
+
+* `/travelnet [network?]` Shows the travelnet formspec for the network (needs the `teleport` priv)
+
 ## License
 
 The mod was written by me, Sokomine, and includes small contributions from other contributors.

--- a/chat.lua
+++ b/chat.lua
@@ -1,0 +1,29 @@
+
+minetest.register_chatcommand("travelnet", {
+    params = "[network?]",
+    description = "Shows the travelnet formspec for the network",
+    privs = {
+        teleport = true
+    },
+    func = function(playername, network_name)
+        if not network_name or network_name == "" then
+            network_name = travelnet.default_network
+        end
+        local networks = travelnet.get_travelnets(playername)
+        local network = networks[network_name]
+        if not network then
+            return false, "Network '" .. network_name .. "' not found"
+        end
+
+        local first_station_name = next(network)
+        if not first_station_name then
+            return false, "No stations found on network '" .. network_name .. "'"
+        end
+
+        local first_station = network[first_station_name]
+        local pos = first_station.pos
+        local meta = minetest.get_meta(pos)
+
+        travelnet.show_current_formspec(pos, meta, playername)
+    end
+})

--- a/chat.lua
+++ b/chat.lua
@@ -6,7 +6,7 @@ minetest.register_chatcommand("travelnet", {
         teleport = true
     },
     func = function(playername, network_name)
-        if not network_name or network_name == "" then
+        if network_name == "" then
             network_name = travelnet.default_network
         end
         local networks = travelnet.get_travelnets(playername)

--- a/formspecs.lua
+++ b/formspecs.lua
@@ -39,9 +39,6 @@ end
 
 function travelnet.formspecs.edit_travelnet(options)
 	if not options then options = {} end
-	-- some players seem to be confused with entering network names at first; provide them
-	-- with a default name
-	local default_network = "net1"
 
 	return ([[
 		size[10,6.0]
@@ -64,10 +61,10 @@ function travelnet.formspecs.edit_travelnet(options)
 		S("Assign to network:"),
 		minetest.formspec_escape(
 			travelnet.is_falsey_string(options.station_network)
-				and default_network
+				and travelnet.default_network
 				or options.station_network
 		),
-		S("You can have more than one network. If unsure, use \"@1\".", default_network),
+		S("You can have more than one network. If unsure, use \"@1\".", travelnet.default_network),
 		S("Owned by:"),
 		minetest.formspec_escape(options.owner_name or ""),
 		S("Unless you know what you are doing, leave this as is."),

--- a/init.lua
+++ b/init.lua
@@ -22,7 +22,11 @@ if not minetest.safe_file_write then
 	error("[Mod travelnet] Your Minetest version is no longer supported. (version < 0.4.17)")
 end
 
-travelnet = {}
+travelnet = {
+	-- some players seem to be confused with entering network names at first; provide them
+	-- with a default name
+	default_network = "net1"
+}
 
 travelnet.log = function(c, msg) minetest.log(c, "[travelnet] " .. msg) end
 travelnet.player_formspec_data = {}
@@ -54,6 +58,9 @@ mod_dofile("update_formspec")
 
 -- add button
 mod_dofile("add_target")
+
+-- chatcommand
+mod_dofile("chat")
 
 -- receive fields handler
 mod_dofile("on_receive_fields")


### PR DESCRIPTION
This PR adds the `/travelnet [network?]` command to show the formspec of an owned travelnet

It shows the first station by default and requires the `teleport` priv