### PR TITLE
MineClonia Support

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -43,7 +43,7 @@ travelnet.tiles_elevator = {
 }
 travelnet.elevator_inventory_image  = "travelnet_elevator_inv.png"
 
-if minetest.registered_nodes["mcl_core:wood"] then
+if minetest.get_modpath("mcl_core") then
 	travelnet.travelnet_recipe = {
 		{ "mcl_core:glass", "mcl_core:iron_ingot",          "mcl_core:glass" },
 		{ "mcl_core:glass", "mesecons_torch:redstoneblock", "mcl_core:glass" },

--- a/doors.lua
+++ b/doors.lua
@@ -132,7 +132,7 @@ if minetest.get_modpath("default") then
 	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "default:glass")
 	travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },              "default:tin_ingot")
 
-elseif minetest.registered_nodes["mcl_core:wood"] then
+elseif minetest.get_modpath("mcl_core") then
 	travelnet.register_door("travelnet:elevator_door_steel", { "default_stone.png" },           "mcl_core:iron_ingot")
 	travelnet.register_door("travelnet:elevator_door_glass", { "travelnet_elevator_door_glass.png" }, "mcl_core:glass")
 	-- travelnet.register_door("travelnet:elevator_door_tin",   { "default_clay.png" },              "default:tin_ingot")

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = travelnet
-optional_depends = mesecons, dye, mtt
+optional_depends = mesecons, dye, mtt, mcl_core
 description = Network of teleporter-boxes that allows easy travelling to other boxes on the same network.


### PR DESCRIPTION
MineClonia use `mcl_trees:wood` id instead `mcl_core:wood`

MineClonia and MineClone2 both use `mcl_core` mod