### PR TITLE
Register travelnet nodes as MVPS stoppers

### DIFF
--- a/elevator.lua
+++ b/elevator.lua
@@ -152,6 +152,10 @@ minetest.register_node("travelnet:elevator", {
 	end
 })
 
+if minetest.get_modpath("mesecons_mvps") then
+	mesecon.register_mvps_stopper("travelnet:elevator")
+end
+
 minetest.register_craft({
 	output = "travelnet:elevator",
 	recipe = travelnet.elevator_recipe,

--- a/init.lua
+++ b/init.lua
@@ -83,6 +83,9 @@ minetest.register_node("travelnet:hidden_top", {
 	drop = "",
 })
 
+if minetest.get_modpath("mesecons_mvps") then
+	mesecon.register_mvps_stopper("travelnet:hidden_top")
+end
 
 if travelnet.travelnet_effect_enabled then
 	minetest.register_entity("travelnet:effect", {

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = travelnet
 depends = xcompat
-optional_depends = mesecons, mtt
+optional_depends = mesecons, mesecons_mvps, mtt
 description = Network of teleporter-boxes that allows easy travelling to other boxes on the same network.

--- a/register_travelnet.lua
+++ b/register_travelnet.lua
@@ -127,4 +127,8 @@ function travelnet.register_travelnet_box(cfg)
 			recipe = { "group:travelnet", cfg.dye },
 		})
 	end
+
+	if minetest.get_modpath("mesecons_mvps") then
+		mesecon.register_mvps_stopper(cfg.nodename)
+	end
 end


### PR DESCRIPTION
Fixes https://github.com/Archtec-io/bugtracker/issues/217
... moving travelnets also removes them from their networks (which makes sense since the coordinates changed)